### PR TITLE
fix(release-pipes): stop builds from tagging version

### DIFF
--- a/.lighthouse/jenkins-x/container-tools/release.yaml
+++ b/.lighthouse/jenkins-x/container-tools/release.yaml
@@ -25,6 +25,9 @@ spec:
           resources: {}
         - name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug

--- a/.lighthouse/jenkins-x/dotnet6sdk/release.yaml
+++ b/.lighthouse/jenkins-x/dotnet6sdk/release.yaml
@@ -25,6 +25,9 @@ spec:
           resources: {}
         - name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug

--- a/.lighthouse/jenkins-x/openjdk14/release.yaml
+++ b/.lighthouse/jenkins-x/openjdk14/release.yaml
@@ -25,6 +25,9 @@ spec:
           resources: {}
         - name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug

--- a/.lighthouse/jenkins-x/openjre11/release.yaml
+++ b/.lighthouse/jenkins-x/openjre11/release.yaml
@@ -25,6 +25,9 @@ spec:
           resources: {}
         - name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug

--- a/.lighthouse/jenkins-x/python310-torch-cpu/release.yaml
+++ b/.lighthouse/jenkins-x/python310-torch-cpu/release.yaml
@@ -25,6 +25,9 @@ spec:
           resources: {}
         - name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug

--- a/.lighthouse/jenkins-x/python310-torch-cuda/release.yaml
+++ b/.lighthouse/jenkins-x/python310-torch-cuda/release.yaml
@@ -25,6 +25,9 @@ spec:
           resources: {}
         - name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug

--- a/.lighthouse/jenkins-x/python310/release.yaml
+++ b/.lighthouse/jenkins-x/python310/release.yaml
@@ -25,6 +25,9 @@ spec:
           resources: {}
         - name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug

--- a/.lighthouse/jenkins-x/python38-torch-cpu/release.yaml
+++ b/.lighthouse/jenkins-x/python38-torch-cpu/release.yaml
@@ -25,6 +25,9 @@ spec:
           resources: {}
         - name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug

--- a/.lighthouse/jenkins-x/python38-torch-cuda/release.yaml
+++ b/.lighthouse/jenkins-x/python38-torch-cuda/release.yaml
@@ -25,6 +25,9 @@ spec:
           resources: {}
         - name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug

--- a/.lighthouse/jenkins-x/python38/release.yaml
+++ b/.lighthouse/jenkins-x/python38/release.yaml
@@ -25,6 +25,9 @@ spec:
           resources: {}
         - name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug


### PR DESCRIPTION
Pipes were failing as all of the build releases were trying to tag their version. This only needs to be done by the main release pipeline, not the builds.