### PR TITLE
fix: install yq and make into base python image

### DIFF
--- a/python310/Dockerfile
+++ b/python310/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 RUN apt-get update \
-    && apt-get install -y gcc libpmix2 software-properties-common curl wget
+    && apt-get install -y gcc libpmix2 software-properties-common curl wget make
 
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq &&\
     chmod +x /usr/bin/yq

--- a/python310/Dockerfile
+++ b/python310/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu:22.04
 RUN apt-get update \
-    && apt-get install gcc libpmix2 -y
+    && apt-get install -y gcc libpmix2 software-properties-common curl wget
+
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq &&\
+    chmod +x /usr/bin/yq
+
 RUN apt upgrade -y
 RUN apt update \
     && DEBIAN_FRONTEND=noninteractive apt install -yq git libopencv-dev python3-opencv libglib2.0-0 libsm6 libxrender1 libxext6 libexpat1-dev libpython3-dev libpython3.10-dev python3-dev python3 python3-distutils wget curl ca-certificates \

--- a/python310/Dockerfile
+++ b/python310/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 RUN apt-get update \
-    && apt-get install -y gcc libpmix2 software-properties-common curl wget make
+    && apt-get install -y gcc libpmix2 wget make
 
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq &&\
     chmod +x /usr/bin/yq


### PR DESCRIPTION
Running the make-config step is needed for some python services and pipelines to run