### PR TITLE
feat: add uv to py image

### DIFF
--- a/python310/Dockerfile
+++ b/python310/Dockerfile
@@ -17,4 +17,5 @@ RUN ln -s /usr/bin/pydoc3 /usr/local/bin/pydoc \
 RUN pip install --upgrade pip \
     && pip install --upgrade setuptools \
     && pip install pipenv
+RUN wget -qO- https://astral.sh/uv/install.sh | sh
 CMD ["bash"]


### PR DESCRIPTION
# Context

Adding [uv](https://docs.astral.sh/uv/) to base python image, as we will slowly integrate it into python services.
Its so much better than all the other solutions.

@Laurencewm already started migrating some services over christmas break (afaik).
Might as well have it in the base image so we can gradually migrate services as we go, and eventually deprecate `pipenv`.