### PR TITLE
fix: python image uv

### DIFF
--- a/python310/Dockerfile
+++ b/python310/Dockerfile
@@ -16,6 +16,6 @@ RUN ln -s /usr/bin/pydoc3 /usr/local/bin/pydoc \
     && python get-pip.py
 RUN pip install --upgrade pip \
     && pip install --upgrade setuptools \
-    && pip install pipenv
-RUN wget -qO- https://astral.sh/uv/install.sh | sh
+    && pip install pipenv \
+    && pip install uv
 CMD ["bash"]


### PR DESCRIPTION
# Changelog

I think the shell script required something extra and didn't support unattended so switching to pip install.
This is a temp solution, once we migrate fully to uv i will switch the image to a more optimal 'uv' image :D