### PR TITLE
feat: add .NET 8 integration tests Dockerfile

### DIFF
--- a/.lighthouse/jenkins-x/net8-integration-tests/pr.yaml
+++ b/.lighthouse/jenkins-x/net8-integration-tests/pr.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: net8-integration-tests-pr
+spec:
+  pipelineSpec:
+    tasks:
+      - name: from-build-pack
+        resources: {}
+        taskSpec:
+          metadata: {}
+          stepTemplate:
+            image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/pullrequest.yaml@versionStream
+            name: ""
+            resources:
+              # override limits for all containers here
+              limits: {}
+            workingDir: /workspace/source
+            env:
+              - name: IMAGE_NAME
+                value: net8-integration-tests
+          steps:
+            - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+              name: ""
+              resources: {}
+            - name: jx-variables
+              resources: {}
+            - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+              name: build-containers
+              resources: {}
+              script: |
+                #!/busybox/sh
+                set -e
+                source .jx/variables.sh
+                cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+
+                /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+            - image: ghcr.io/spring-financial-group/container-tools:latest
+              name: push-containers
+              resources: {}
+              script: |
+                #!/bin/bash
+                set -e
+                source .jx/variables.sh
+                cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson ~/.docker/config.json
+
+                crane push /workspace/source/$IMAGE_NAME.tar $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+                cosign sign --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+                cosign verify --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/net8-integration-tests/release.yaml
+++ b/.lighthouse/jenkins-x/net8-integration-tests/release.yaml
@@ -1,0 +1,64 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: net8-integration-tests-release
+spec:
+  pipelineSpec:
+    tasks:
+      - name: from-build-pack
+        resources: {}
+        taskSpec:
+          metadata: {}
+          stepTemplate:
+            image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/release.yaml@versionStream
+            name: ""
+            resources:
+              # override limits for all containers here
+              limits: {}
+            workingDir: /workspace/source
+            env:
+              - name: IMAGE_NAME
+                value: net8-integration-tests
+          steps:
+            - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+              name: ""
+              resources: {}
+            - name: next-version
+              resources: {}
+              script: |
+                #!/usr/bin/env sh
+                jx-release-version > VERSION
+            - name: jx-variables
+              resources: {}
+            - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+              name: build-containers
+              resources: {}
+              script: |
+                #!/busybox/sh
+                set -e
+                source .jx/variables.sh
+                cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+
+                /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+            - image: ghcr.io/spring-financial-group/container-tools:latest
+              name: push-containers
+              resources: {}
+              script: |
+                #!/bin/bash
+                set -e
+                source .jx/variables.sh
+                cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson ~/.docker/config.json
+
+                ## Push & sign versioned image
+                crane push /workspace/source/$IMAGE_NAME.tar $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+                cosign sign --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+                cosign verify --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+
+                ## Push & sign latest image
+                crane push /workspace/source/$IMAGE_NAME.tar $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:latest
+                cosign sign --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:latest
+                cosign verify --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:latest
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -38,6 +38,10 @@ spec:
     optional: false
     run_if_changed: ^.*terra-test\/.*$
     source: "/terra-test/pr.yaml"
+  - name: net8-integration-tests-pr
+    optional: false
+    run_if_changed: ^.*net8-integration-tests\/.*$
+    source: "/net8-integration-tests/pr.yaml"
   postsubmits:
   - name: release
     source: "release.yaml"
@@ -91,6 +95,11 @@ spec:
       - ^master$
   - name: terra-test-release
     source: "/terra-test/release.yaml"
+    branches:
+      - ^main$
+      - ^master$
+  - name: net8-integration-tests-release
+    source: "/net8-integration-tests/release.yaml"
     branches:
       - ^main$
       - ^master$

--- a/net8-integration-tests/Dockerfile
+++ b/net8-integration-tests/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
+
+RUN apt update && apt install -y gnupg
+
+RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
+RUN gpg --keyserver keyserver.ubuntu.com --recv-keys 871920D1991BC93C
+
+RUN gpg --export --armor 3B4FE6ACC0B21F32 | apt-key add -
+RUN gpg --export --armor 871920D1991BC93C | apt-key add -
+
+RUN echo "deb http://security.ubuntu.com/ubuntu focal-security main" | tee /etc/apt/sources.list.d/focal-security.list
+
+RUN apt update
+RUN apt install -y libssl1.1
+
+CMD ["bash"]


### PR DESCRIPTION
### Changelog
- Add .NET 8 integration tests dockerfile with libssl1.1 installed

### Context
When using Mongo2Go to run integration tests in a docker container within a pipeline, we require libssl1.1 to be installed, which is not installed by default in the base net8 sdk image.