### PR TITLE
chore: upgrade golang on terratest image

### DIFF
--- a/terra-test/Dockerfile
+++ b/terra-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:1.19.0
+FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:1.24
 
 RUN apt-get update \
     && apt-get install -y unzip jq \


### PR DESCRIPTION
Upgrading golang version on terratest image to cope with some of the packages used..