### PR TITLE
fix: no longer use golang alpine

### DIFF
--- a/golang-chromium/Dockerfile
+++ b/golang-chromium/Dockerfile
@@ -1,4 +1,5 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:1.24-alpine
+FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:1.24
 
-RUN apk upgrade --no-cache \
- && apk --no-cache add chromium \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends chromium \
+    && apt-get clean


### PR DESCRIPTION
So it seems that the alpine version of the golang container doesn't contain all of the tools (like make or git) to build things, so rather than going through the pain of installing all these into an alpine image, might as well just change over to using the base golang image.

especially given:
> This variant (`golang:<version>-alpine`) is highly experimental, and not officially supported by the Go project
> \- https://hub.docker.com/_/golang