### PR TITLE
chore: update tf version on terratest image

### DIFF
--- a/terra-test/Dockerfile
+++ b/terra-test/Dockerfile
@@ -2,11 +2,17 @@ FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:1.24
 
 RUN apt-get update \
     && apt-get install -y unzip jq \
-    && export LATEST_TF_VERSION=$(curl -sL https://releases.hashicorp.com/terraform/index.json | jq -r '.versions[].builds[].url' | egrep -v 'rc|beta|alpha' | egrep 'linux.*amd64'  | tail -1) \
-    && wget $LATEST_TF_VERSION \
-    && export TERRAFORM_FILENAME=$(echo $LATEST_TF_VERSION | grep -oP '[^/]+\.zip$') \
-    && unzip $TERRAFORM_FILENAME && echo $TERRAFORM_FILENAME \
-    && rm $TERRAFORM_FILENAME \
+    && TERRAFORM_VERSION=$(curl -sL https://releases.hashicorp.com/terraform/index.json \
+        | jq -r '.versions | to_entries[] | select(.key | test("^(?!.*(alpha|beta|rc)).*")) | .key' \
+        | sort -V \
+        | tail -1) \
+    && echo "Latest Terraform version: $TERRAFORM_VERSION" \
+    && TERRAFORM_URL=$(curl -sL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/index.json" \
+        | jq -r '.builds[] | select(.arch == "amd64" and .os == "linux") | .url') \
+    && wget "$TERRAFORM_URL" \
+    && export TERRAFORM_FILENAME=$(echo "$TERRAFORM_URL" | grep -oP '[^/]+\.zip$') \
+    && unzip "$TERRAFORM_FILENAME" && echo "$TERRAFORM_FILENAME" \
+    && rm "$TERRAFORM_FILENAME" \
     && mv terraform /usr/local/go/bin/terraform \
     && curl -L -o tfsec "https://github.com/aquasecurity/tfsec/releases/download/v1.28.14/tfsec-linux-amd64" \
     && chmod +x tfsec \


### PR DESCRIPTION
Updated version of terraform on terratest image..

Existing process wasn't sorting the version index returned from hashicorp.
This meant we just took the last instance of an unsorted object which didn't guarantee the latest version.
Updated to gather latest version then curl the relevant URL for the download details.

Tested build locally -

```
❯ docker run -it ttest-new:latest bash
root@2bfedcba210c:/go# terraform version
Terraform v1.12.2
on linux_amd64
```