### PR TITLE
fix: Add a Geth bootnode pre build Docker image

### DIFF
--- a/.lighthouse/jenkins-x/bootnode/pr.yaml
+++ b/.lighthouse/jenkins-x/bootnode/pr.yaml
@@ -1,0 +1,63 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: bootnode-pr
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/pullrequest.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+          volumeMounts:
+          - mountPath: /temp-docker-config
+            name: temp-docker-config
+          env:
+          - name: IMAGE_NAME
+            value: bootnode
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: jx-variables
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+          name: build-containers
+          resources: {}
+          script: |
+            #!/busybox/sh
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json /kaniko/.docker/config.json
+
+            /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: ghcr.io/spring-financial-group/container-tools:latest
+          name: push-containers
+          resources: {}
+          script: |
+            #!/bin/bash
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json ~/.docker/config.json
+
+            crane push /workspace/source/$IMAGE_NAME.tar $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            cosign sign --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            cosign verify --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+        volumes:
+        - name: temp-docker-config
+          secret:
+            secretName: tekton-temp-registry-auth
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/bootnode/release.yaml
+++ b/.lighthouse/jenkins-x/bootnode/release.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: bootnode-release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/release.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+          volumeMounts:
+          - mountPath: /temp-docker-config
+            name: temp-docker-config
+          env:
+          - name: IMAGE_NAME
+            value: bootnode
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: next-version
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
+        - name: jx-variables
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+          name: build-containers
+          resources: {}
+          script: |
+            #!/busybox/sh
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json /kaniko/.docker/config.json
+
+            /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: ghcr.io/spring-financial-group/container-tools:latest
+          name: push-containers
+          resources: {}
+          script: |
+            #!/bin/bash
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json ~/.docker/config.json
+
+            ## Push & sign versioned image
+            crane push /workspace/source/$IMAGE_NAME.tar $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            cosign sign --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            cosign verify --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+
+            ## Push & sign latest image
+            crane push /workspace/source/$IMAGE_NAME.tar $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:latest
+            cosign sign --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:latest
+            cosign verify --key k8s://jx-staging/cosign $PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:latest
+        volumes:
+        - name: temp-docker-config
+          secret:
+            secretName: tekton-temp-registry-auth
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -26,6 +26,10 @@ spec:
     optional: false
     run_if_changed: (README.md|^.*python310-torch-cuda\/.*$)
     source: "/python310-torch-cuda/pr.yaml"
+  - name: bootnode-pr
+    optional: false
+    run_if_changed: (README.md|^.*nginx\/.*$)
+    source: "/bootnode/pr.yaml"
   - name: nginx-pr
     optional: false
     run_if_changed: (README.md|^.*nginx\/.*$)
@@ -105,6 +109,11 @@ spec:
     - ^master$
   - name: node-release
     source: "/node/release.yaml"
+    branches:
+    - ^main$
+    - ^master$
+  - name: bootnode-release
+    source: "/bootnode/release.yaml"
     branches:
     - ^main$
     - ^master$

--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -28,7 +28,7 @@ spec:
     source: "/python310-torch-cuda/pr.yaml"
   - name: bootnode-pr
     optional: false
-    run_if_changed: (README.md|^.*nginx\/.*$)
+    run_if_changed: (README.md|^.*bootnode\/.*$)
     source: "/bootnode/pr.yaml"
   - name: nginx-pr
     optional: false

--- a/bootnode/Dockerfile
+++ b/bootnode/Dockerfile
@@ -1,69 +1,45 @@
-# -------------------------
-# builder: compile bootnode + a tiny hex->raw helper
-# -------------------------
+# ---- builder: compile bootnode + hex2raw ----
 FROM golang:1.22-alpine AS builder
 ARG GETH_VER=v1.14.12
 
 RUN apk add --no-cache git
 RUN go install github.com/ethereum/go-ethereum/cmd/bootnode@${GETH_VER}
 
-# build a tiny helper that writes raw 32 bytes from a hex string to stdout
-RUN cat > /tmp/hex2raw.go <<'EOF' && \
-    go build -o /hex2raw /tmp/hex2raw.go
-package main
-import (
-	"encoding/hex"
-	"fmt"
-	"os"
-)
-func main() {
-	if len(os.Args) != 2 {
-		fmt.Fprintln(os.Stderr, "usage: hex2raw <64-hex-chars>"); os.Exit(2)
-	}
-	b, err := hex.DecodeString(os.Args[1])
-	if err != nil || len(b) != 32 {
-		fmt.Fprintln(os.Stderr, "invalid hex (need 32 bytes/64 hex chars)"); os.Exit(2)
-	}
-	os.Stdout.Write(b)
-}
-EOF
+# build tiny helper to turn 64-hex -> raw 32 bytes
+RUN printf '%s\n' \
+  'package main' \
+  '' \
+  'import (' \
+  '  "encoding/hex"' \
+  '  "fmt"' \
+  '  "os"' \
+  ')' \
+  '' \
+  'func main() {' \
+  '  if len(os.Args) != 2 {' \
+  '    fmt.Fprintln(os.Stderr, "usage: hex2raw <64-hex-chars>"); os.Exit(2)' \
+  '  }' \
+  '  b, err := hex.DecodeString(os.Args[1])' \
+  '  if err != nil || len(b) != 32 {' \
+  '    fmt.Fprintln(os.Stderr, "invalid hex (need 32 bytes/64 hex chars)"); os.Exit(2)' \
+  '  }' \
+  '  os.Stdout.Write(b)' \
+  '}' \
+  > /tmp/hex2raw.go \
+ && go build -o /hex2raw /tmp/hex2raw.go
 
-# -------------------------
-# final image: minimal Alpine, non-root, no package installs at runtime
-# -------------------------
+# ---- final: minimal, non-root, no apk/go at runtime ----
 FROM alpine:3.20
 
-# Create non-root user
+# non-root user
 RUN addgroup -S app && adduser -S -G app app
 
-# Copy binaries
+# copy binaries from builder
 COPY --from=builder /go/bin/bootnode /usr/local/bin/bootnode
 COPY --from=builder /hex2raw            /usr/local/bin/hex2raw
 
-# tiny entrypoint that chooses nodekey source and runs bootnode
-COPY --chown=app:app <<'EOF' /usr/local/bin/run.sh
-#!/bin/sh
-set -eu
-
-mkdir -p /data
-# priority: mounted secret > env var
-if [ -f /secrets/nodekey ]; then
-  cp /secrets/nodekey /data/nodekey
-elif [ -n "${NODEKEY_HEX:-}" ]; then
-  hex2raw "$NODEKEY_HEX" > /data/nodekey
-else
-  echo "ERROR: provide /secrets/nodekey (raw 32 bytes) or NODEKEY_HEX env" >&2
-  exit 1
-fi
-
-PUB=$(bootnode -nodekey /data/nodekey -writeaddress)
-PORT="${BOOTNODE_PORT:-30301}"
-IP="${POD_IP:-0.0.0.0}"
-
-echo "BOOTNODE_ENODE=enode://${PUB}@${IP}:${PORT}"
-exec bootnode -nodekey /data/nodekey -addr ":${PORT}"
-EOF
-
+# copy entrypoint script from context
+COPY run.sh /usr/local/bin/run.sh
 RUN chmod +x /usr/local/bin/run.sh && \
     mkdir -p /secrets /data && chown -R app:app /secrets /data
 

--- a/bootnode/Dockerfile
+++ b/bootnode/Dockerfile
@@ -1,0 +1,73 @@
+# -------------------------
+# builder: compile bootnode + a tiny hex->raw helper
+# -------------------------
+FROM golang:1.22-alpine AS builder
+ARG GETH_VER=v1.14.12
+
+RUN apk add --no-cache git
+RUN go install github.com/ethereum/go-ethereum/cmd/bootnode@${GETH_VER}
+
+# build a tiny helper that writes raw 32 bytes from a hex string to stdout
+RUN cat > /tmp/hex2raw.go <<'EOF' && \
+    go build -o /hex2raw /tmp/hex2raw.go
+package main
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+)
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: hex2raw <64-hex-chars>"); os.Exit(2)
+	}
+	b, err := hex.DecodeString(os.Args[1])
+	if err != nil || len(b) != 32 {
+		fmt.Fprintln(os.Stderr, "invalid hex (need 32 bytes/64 hex chars)"); os.Exit(2)
+	}
+	os.Stdout.Write(b)
+}
+EOF
+
+# -------------------------
+# final image: minimal Alpine, non-root, no package installs at runtime
+# -------------------------
+FROM alpine:3.20
+
+# Create non-root user
+RUN addgroup -S app && adduser -S -G app app
+
+# Copy binaries
+COPY --from=builder /go/bin/bootnode /usr/local/bin/bootnode
+COPY --from=builder /hex2raw            /usr/local/bin/hex2raw
+
+# tiny entrypoint that chooses nodekey source and runs bootnode
+COPY --chown=app:app <<'EOF' /usr/local/bin/run.sh
+#!/bin/sh
+set -eu
+
+mkdir -p /data
+# priority: mounted secret > env var
+if [ -f /secrets/nodekey ]; then
+  cp /secrets/nodekey /data/nodekey
+elif [ -n "${NODEKEY_HEX:-}" ]; then
+  hex2raw "$NODEKEY_HEX" > /data/nodekey
+else
+  echo "ERROR: provide /secrets/nodekey (raw 32 bytes) or NODEKEY_HEX env" >&2
+  exit 1
+fi
+
+PUB=$(bootnode -nodekey /data/nodekey -writeaddress)
+PORT="${BOOTNODE_PORT:-30301}"
+IP="${POD_IP:-0.0.0.0}"
+
+echo "BOOTNODE_ENODE=enode://${PUB}@${IP}:${PORT}"
+exec bootnode -nodekey /data/nodekey -addr ":${PORT}"
+EOF
+
+RUN chmod +x /usr/local/bin/run.sh && \
+    mkdir -p /secrets /data && chown -R app:app /secrets /data
+
+USER app
+EXPOSE 30301/udp
+ENTRYPOINT ["/usr/local/bin/run.sh"]
+

--- a/bootnode/run.sh
+++ b/bootnode/run.sh
@@ -4,7 +4,7 @@ set -eu
 STATE_DIR=${STATE_DIR:-/data}
 mkdir -p "$STATE_DIR"
 
-if [ -f /secrets/nodekey ]; then
+if [ -f /secrets/nodekey-hex ]; then
   # raw 32 bytes
   cp /secrets/nodekey "$STATE_DIR/nodekey"
 elif [ -f /secrets/nodekey-hex ]; then

--- a/bootnode/run.sh
+++ b/bootnode/run.sh
@@ -4,25 +4,29 @@ set -eu
 STATE_DIR=${STATE_DIR:-/data}
 mkdir -p "$STATE_DIR"
 
+KEY_FLAG=""
+
 if [ -f /secrets/nodekey ]; then
-  # raw 32 bytes
+  # raw 32 bytes (preferred)
   cp /secrets/nodekey "$STATE_DIR/nodekey"
+  KEY_FLAG="-nodekey $STATE_DIR/nodekey"
 elif [ -f /secrets/nodekey-hex ]; then
-  # 64 hex chars -> raw
+  # 64 hex chars (no 0x)
   HEX="$(tr -d '\n\r' </secrets/nodekey-hex)"
-  hex2raw "$HEX" > "$STATE_DIR/nodekey"
+  KEY_FLAG="-nodekeyhex $HEX"
 elif [ -n "${NODEKEY_HEX:-}" ]; then
-  # env hex fallback
-  hex2raw "$NODEKEY_HEX" > "$STATE_DIR/nodekey"
+  # env fallback: 64 hex chars
+  KEY_FLAG="-nodekeyhex $NODEKEY_HEX"
 else
   echo "ERROR: provide /secrets/nodekey (raw 32 bytes), /secrets/nodekey-hex (64 hex), or NODEKEY_HEX env" >&2
   exit 1
 fi
 
-PUB=$(bootnode -nodekeyfile "$STATE_DIR/nodekey" -writeaddress)
 PORT="${BOOTNODE_PORT:-30301}"
 IP="${POD_IP:-0.0.0.0}"
 
+PUB=$(sh -c "bootnode $KEY_FLAG -writeaddress")
 echo "BOOTNODE_ENODE=enode://${PUB}@${IP}:${PORT}"
-exec bootnode -nodekeyfile "$STATE_DIR/nodekey" -addr ":${PORT}"
+
+exec sh -c "exec bootnode $KEY_FLAG -addr :${PORT}"
 

--- a/bootnode/run.sh
+++ b/bootnode/run.sh
@@ -19,10 +19,10 @@ else
   exit 1
 fi
 
-PUB=$(bootnode -nodekey "$STATE_DIR/nodekey" -writeaddress)
+PUB=$(bootnode -nodekeyfile "$STATE_DIR/nodekey" -writeaddress)
 PORT="${BOOTNODE_PORT:-30301}"
 IP="${POD_IP:-0.0.0.0}"
 
 echo "BOOTNODE_ENODE=enode://${PUB}@${IP}:${PORT}"
-exec bootnode -nodekey "$STATE_DIR/nodekey" -addr ":${PORT}"
+exec bootnode -nodekeyfile "$STATE_DIR/nodekey" -addr ":${PORT}"
 

--- a/bootnode/run.sh
+++ b/bootnode/run.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /data
+# Priority: mounted secret (/secrets/nodekey) > env var NODEKEY_HEX
+if [ -f /secrets/nodekey ]; then
+  cp /secrets/nodekey /data/nodekey
+elif [ -n "${NODEKEY_HEX:-}" ]; then
+  hex2raw "$NODEKEY_HEX" > /data/nodekey
+else
+  echo "ERROR: provide /secrets/nodekey (raw 32 bytes) or NODEKEY_HEX env" >&2
+  exit 1
+fi
+
+PUB=$(bootnode -nodekey /data/nodekey -writeaddress)
+PORT="${BOOTNODE_PORT:-30301}"
+IP="${POD_IP:-0.0.0.0}"
+
+echo "BOOTNODE_ENODE=enode://${PUB}@${IP}:${PORT}"
+exec bootnode -nodekey /data/nodekey -addr ":${PORT}"
+

--- a/bootnode/run.sh
+++ b/bootnode/run.sh
@@ -4,12 +4,13 @@ set -eu
 STATE_DIR=${STATE_DIR:-/data}
 mkdir -p "$STATE_DIR"
 
-if [ -f /secrets/nodekey-hex ]; then
+if [ -f /secrets/nodekey ]; then
   # raw 32 bytes
   cp /secrets/nodekey "$STATE_DIR/nodekey"
 elif [ -f /secrets/nodekey-hex ]; then
   # 64 hex chars -> raw
-  hex2raw "$(cat /secrets/nodekey-hex)" > "$STATE_DIR/nodekey"
+  HEX="$(tr -d '\n\r' </secrets/nodekey-hex)"
+  hex2raw "$HEX" > "$STATE_DIR/nodekey"
 elif [ -n "${NODEKEY_HEX:-}" ]; then
   # env hex fallback
   hex2raw "$NODEKEY_HEX" > "$STATE_DIR/nodekey"

--- a/bootnode/run.sh
+++ b/bootnode/run.sh
@@ -1,21 +1,27 @@
 #!/bin/sh
 set -eu
 
-mkdir -p /data
-# Priority: mounted secret (/secrets/nodekey) > env var NODEKEY_HEX
+STATE_DIR=${STATE_DIR:-/data}
+mkdir -p "$STATE_DIR"
+
 if [ -f /secrets/nodekey ]; then
-  cp /secrets/nodekey /data/nodekey
+  # raw 32 bytes
+  cp /secrets/nodekey "$STATE_DIR/nodekey"
+elif [ -f /secrets/nodekey-hex ]; then
+  # 64 hex chars -> raw
+  hex2raw "$(cat /secrets/nodekey-hex)" > "$STATE_DIR/nodekey"
 elif [ -n "${NODEKEY_HEX:-}" ]; then
-  hex2raw "$NODEKEY_HEX" > /data/nodekey
+  # env hex fallback
+  hex2raw "$NODEKEY_HEX" > "$STATE_DIR/nodekey"
 else
-  echo "ERROR: provide /secrets/nodekey (raw 32 bytes) or NODEKEY_HEX env" >&2
+  echo "ERROR: provide /secrets/nodekey (raw 32 bytes), /secrets/nodekey-hex (64 hex), or NODEKEY_HEX env" >&2
   exit 1
 fi
 
-PUB=$(bootnode -nodekey /data/nodekey -writeaddress)
+PUB=$(bootnode -nodekey "$STATE_DIR/nodekey" -writeaddress)
 PORT="${BOOTNODE_PORT:-30301}"
 IP="${POD_IP:-0.0.0.0}"
 
 echo "BOOTNODE_ENODE=enode://${PUB}@${IP}:${PORT}"
-exec bootnode -nodekey /data/nodekey -addr ":${PORT}"
+exec bootnode -nodekey "$STATE_DIR/nodekey" -addr ":${PORT}"
 


### PR DESCRIPTION
Add a Bootnode image as there aren't any built that have the tools needed to get enode keys , this allows us to set up bootnodes to discover geth nodes going forward