### PR TITLE
feat: container-tools acr cred test; update packages

### DIFF
--- a/container-tools/.trivyignore.yaml
+++ b/container-tools/.trivyignore.yaml
@@ -2,3 +2,6 @@ vulnerabilities:
   # Docker CLI for Windows vulnerability
   - id: CVE-2025-15558
     expired_at: 2026-06-01
+  # OpenTelemetry Go SDK Vulnerable to Arbitrary Code Execution via PATH Hijacking
+  - id: CVE-2026-24051
+    expired_at: 2026-06-01

--- a/container-tools/.trivyignore.yaml
+++ b/container-tools/.trivyignore.yaml
@@ -1,23 +1,4 @@
 vulnerabilities:
-  - id: CVE-2024-41110
-    expired_at: 2026-03-31
-  - id: CVE-2024-45337
-    expired_at: 2026-03-31
+  # Docker CLI for Windows vulnerability
   - id: CVE-2025-15558
-    expired_at: 2026-03-31
-  - id: CVE-2025-30204
-    expired_at: 2026-03-31
-  - id: CVE-2025-26519
-    expired_at: 2026-03-31
-  - id: CVE-2025-66506
-    expired_at: 2026-03-31
-  - id: CVE-2025-66564
-    expired_at: 2026-03-31
-  - id: CVE-2025-22868
-    expired_at: 2026-03-31
-  - id: CVE-2025-22869
-    expired_at: 2026-03-31
-  - id: CVE-2025-46569
-    expired_at: 2026-03-31
-  - id: CVE-2026-24051
-    expired_at: 2026-03-31
+    expired_at: 2026-06-01

--- a/container-tools/Dockerfile
+++ b/container-tools/Dockerfile
@@ -1,22 +1,23 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/bitnamilegacy/kubectl:1.32 AS kubectl
+FROM jx3mqubebuild.azurecr.io/docker-io/alpine/kubectl:1.33.3 AS kubectl
 
 FROM jx3mqubebuild.azurecr.io/docker-io/library/alpine:3.16
-RUN apk add --no-cache ca-certificates curl wget bash git make yq jq github-cli zip
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache ca-certificates curl wget bash git make yq jq github-cli zip
 
 RUN mkdir /source && cd /source
-RUN wget -nv https://github.com/jenkins-x/docker-credential-acr-env/releases/download/v0.0.4/docker-credential-acr-env_0.0.4_linux_amd64.tar.gz \
-    && tar -xzvf docker-credential-acr-env_0.0.4_linux_amd64.tar.gz \
+RUN wget -nv https://github.com/spring-financial-group/docker-credential-acr-env/releases/download/v0.0.72-alpha/docker-credential-acr-env \
     && mv docker-credential-acr-env /bin/docker-credential-acr-env \
     && chmod +x /bin/docker-credential-acr-env
 
-RUN wget -nv https://github.com/sigstore/cosign/releases/download/v2.3.0/cosign-linux-amd64 \
+RUN wget -nv https://github.com/sigstore/cosign/releases/download/v3.0.5/cosign-linux-amd64 \
     && mv cosign-linux-amd64 /bin/cosign \
     && chmod +x /bin/cosign
 
-RUN wget -nv https://github.com/google/go-containerregistry/releases/download/v0.16.1/go-containerregistry_Linux_x86_64.tar.gz \
+RUN wget -nv https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_x86_64.tar.gz \
     && tar -xzvf go-containerregistry_Linux_x86_64.tar.gz \
     && mv crane /bin/crane \
     && chmod +x /bin/crane
 
-COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
+#COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 CMD ["bash"]

--- a/container-tools/Dockerfile
+++ b/container-tools/Dockerfile
@@ -19,5 +19,4 @@ RUN wget -nv https://github.com/google/go-containerregistry/releases/download/v0
     && mv crane /bin/crane \
     && chmod +x /bin/crane
 
-#COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
 CMD ["bash"]


### PR DESCRIPTION
### Changes
* Use refactored `docker-credential-acr-anv` -  https://github.com/spring-financial-group/docker-credential-acr-env/pull/76
* Use kubectl alpine image `1.33.3`
* Update cosign and crane to latest versions
* Run `apk update` in build image
* Update `.trivyignore` 

### Context

Test refactor of `docker-credential-acr-anv` in our environment before pushing a JX fix upstream

Stop using bitnami kubectl image, as it's unsupported now

Binaries and library updates
