### PR TITLE
feat: add all-sdks image

### DIFF
--- a/.lighthouse/jenkins-x/all-sdks/pr.yaml
+++ b/.lighthouse/jenkins-x/all-sdks/pr.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: all-sdks-pr
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/pullrequest.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+          volumeMounts:
+          - mountPath: /temp-docker-config
+            name: temp-docker-config
+          env:
+          - name: IMAGE_NAME
+            value: all-sdks
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: jx-variables
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+          name: build-containers
+          resources: {}
+          script: |
+            #!/busybox/sh
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json /kaniko/.docker/config.json
+            
+            /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: push-sign-verify-containers
+          resources: {}
+          script: |
+            #!/bin/bash
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json ~/.docker/config.json
+            IMAGE_REF=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            crane push /workspace/source/$IMAGE_NAME.tar $IMAGE_REF
+            IMAGE_DIGEST=$(crane digest $IMAGE_REF)
+            IMAGE_WITH_DIGEST=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME@$IMAGE_DIGEST
+            cosign sign --yes --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            cosign verify --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            rm -f /workspace/source/$IMAGE_NAME.tar /workspace/source/scanresults.txt
+        volumes:
+        - name: temp-docker-config
+          secret:
+            secretName: tekton-temp-registry-auth
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/all-sdks/release.yaml
+++ b/.lighthouse/jenkins-x/all-sdks/release.yaml
@@ -1,0 +1,79 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: all-sdks-release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/release.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+          volumeMounts:
+          - mountPath: /temp-docker-config
+            name: temp-docker-config
+          env:
+          - name: IMAGE_NAME
+            value: all-sdks
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: next-version
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
+        - name: jx-variables
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+          name: build-containers
+          resources: {}
+          script: |
+            #!/busybox/sh
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json /kaniko/.docker/config.json
+            
+            /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: push-sign-verify-containers
+          resources: {}
+          script: |
+            #!/bin/bash
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json ~/.docker/config.json
+            
+            # Push the image using crane and get the digest
+            IMAGE_REF=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            crane push /workspace/source/$IMAGE_NAME.tar $IMAGE_REF
+            IMAGE_DIGEST=$(crane digest $IMAGE_REF)
+            IMAGE_WITH_DIGEST=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME@$IMAGE_DIGEST
+            
+            # Sign the image with cosign and verify the signature
+            cosign sign --yes --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            cosign verify --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            
+            # Retag to latest (same digest, no re-sign needed)
+            crane tag $IMAGE_REF latest
+            
+            rm -f /workspace/source/$IMAGE_NAME.tar /workspace/source/scanresults.txt
+        volumes:
+        - name: temp-docker-config
+          secret:
+            secretName: tekton-temp-registry-auth
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -6,6 +6,10 @@ spec:
     optional: false
     run_if_changed: (README.md|^.*container-tools\/.*$)
     source: "/container-tools/pr.yaml"
+  - name: all-sdks-pr
+    optional: false
+    run_if_changed: (README.md|^.*all-sdks\/.*$)
+    source: "/all-sdks/pr.yaml"
   - name: openjdk14-pr
     optional: false
     run_if_changed: (README.md|^.*openjdk14\/.*$)
@@ -93,6 +97,11 @@ spec:
     - ^master$
   - name: container-tools-release
     source: "/container-tools/release.yaml"
+    branches:
+    - ^main$
+    - ^master$
+  - name: all-sdks-release
+    source: "/all-sdks/release.yaml"
     branches:
     - ^main$
     - ^master$

--- a/all-sdks/Dockerfile
+++ b/all-sdks/Dockerfile
@@ -1,0 +1,47 @@
+FROM ghcr.io/astral-sh/uv:0.11.7-python3.10-trixie
+
+# Avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Language versions
+ENV NODE_VERSION="24.13.0"
+ENV GO_VERSION="1.24.4"
+ENV DOTNET_VERSION="8.0"
+ENV GRADLE_VERSION="8.13"
+ENV JAVA_VERSION="17"
+ENV YQ_VERSION="v4.53.2"
+
+# upgrade all packages
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
+    && apt-get upgrade -y
+
+    # NodeJS
+RUN wget --https-only --max-redirect=0 -qO- "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" | tar -xJ -C /usr/local --strip-components=1 \
+    # Go
+    && wget --https-only --max-redirect=0 -qO- "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz -C /usr/local \
+    # yq
+    && wget --https-only --max-redirect=2 -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+    && chmod +x /usr/local/bin/yq \
+    # .NET
+    && wget --https-only --max-redirect=0 -q https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh -O /tmp/dotnet-install.sh \
+    && chmod +x /tmp/dotnet-install.sh \
+    && /tmp/dotnet-install.sh --channel "${DOTNET_VERSION}" --install-dir /usr/share/dotnet \
+    && rm /tmp/dotnet-install.sh \
+    # Java
+    && wget --https-only --max-redirect=2 -q "https://api.adoptium.net/v3/binary/latest/${JAVA_VERSION}/ga/linux/x64/jdk/hotspot/normal/adoptium" \
+        -O /tmp/jdk.tar.gz \
+    && mkdir -p "/usr/lib/jvm/temurin-${JAVA_VERSION}" \
+    && tar -xz -C "/usr/lib/jvm/temurin-${JAVA_VERSION}" --strip-components=1 -f /tmp/jdk.tar.gz \
+    && rm /tmp/jdk.tar.gz \
+    # Gradle
+    && wget --https-only --max-redirect=2 -q "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+    && mkdir /opt/gradle \
+    && unzip -d /opt/gradle "gradle-${GRADLE_VERSION}-bin.zip" \
+    && rm "gradle-${GRADLE_VERSION}-bin.zip"
+
+ENV GOPATH="/usr/local/go"
+ENV DOTNET_ROOT="/usr/share/dotnet"
+ENV JAVA_HOME="/usr/lib/jvm/temurin-${JAVA_VERSION}"
+ENV PATH="${PATH}:/usr/local/go/bin:/usr/share/dotnet:/usr/lib/jvm/temurin-${JAVA_VERSION}/bin:/opt/gradle/gradle-${GRADLE_VERSION}/bin"


### PR DESCRIPTION
### Changes
* Add Single docker image containing all SDKs

### Context
An image containing all sdks is useful for building CLIs which require target repos environments to run.
Examples include:
- rule-generator
- jx3-openapi