### PR TITLE
feat: add all-sdks-debian image

### DIFF
--- a/.lighthouse/jenkins-x/all-sdks-debian/pr.yaml
+++ b/.lighthouse/jenkins-x/all-sdks-debian/pr.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: all-sdks-debian-pr
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/pullrequest.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+          volumeMounts:
+          - mountPath: /temp-docker-config
+            name: temp-docker-config
+          env:
+          - name: IMAGE_NAME
+            value: all-sdks-debian
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: jx-variables
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+          name: build-containers
+          resources: {}
+          script: |
+            #!/busybox/sh
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json /kaniko/.docker/config.json
+            
+            /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: push-sign-verify-containers
+          resources: {}
+          script: |
+            #!/bin/bash
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json ~/.docker/config.json
+            IMAGE_REF=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            crane push /workspace/source/$IMAGE_NAME.tar $IMAGE_REF
+            IMAGE_DIGEST=$(crane digest $IMAGE_REF)
+            IMAGE_WITH_DIGEST=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME@$IMAGE_DIGEST
+            cosign sign --yes --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            cosign verify --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            rm -f /workspace/source/$IMAGE_NAME.tar /workspace/source/scanresults.txt
+        volumes:
+        - name: temp-docker-config
+          secret:
+            secretName: tekton-temp-registry-auth
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/all-sdks-debian/release.yaml
+++ b/.lighthouse/jenkins-x/all-sdks-debian/release.yaml
@@ -1,0 +1,79 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: all-sdks-debian-release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/release.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+          volumeMounts:
+          - mountPath: /temp-docker-config
+            name: temp-docker-config
+          env:
+          - name: IMAGE_NAME
+            value: all-sdks-debian
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: next-version
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
+        - name: jx-variables
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+          name: build-containers
+          resources: {}
+          script: |
+            #!/busybox/sh
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json /kaniko/.docker/config.json
+            
+            /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: push-sign-verify-containers
+          resources: {}
+          script: |
+            #!/bin/bash
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json ~/.docker/config.json
+            
+            # Push the image using crane and get the digest
+            IMAGE_REF=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            crane push /workspace/source/$IMAGE_NAME.tar $IMAGE_REF
+            IMAGE_DIGEST=$(crane digest $IMAGE_REF)
+            IMAGE_WITH_DIGEST=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME@$IMAGE_DIGEST
+            
+            # Sign the image with cosign and verify the signature
+            cosign sign --yes --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            cosign verify --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            
+            # Retag to latest (same digest, no re-sign needed)
+            crane tag $IMAGE_REF latest
+            
+            rm -f /workspace/source/$IMAGE_NAME.tar /workspace/source/scanresults.txt
+        volumes:
+        - name: temp-docker-config
+          secret:
+            secretName: tekton-temp-registry-auth
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -10,6 +10,10 @@ spec:
     optional: false
     run_if_changed: (README.md|^.*all-sdks-alpine\/.*$)
     source: "/all-sdks-alpine/pr.yaml"
+  - name: all-sdks-debian-pr
+    optional: false
+    run_if_changed: (README.md|^.*all-sdks-debian\/.*$)
+    source: "/all-sdks-debian/pr.yaml"
   - name: openjdk14-pr
     optional: false
     run_if_changed: (README.md|^.*openjdk14\/.*$)
@@ -102,6 +106,11 @@ spec:
     - ^master$
   - name: all-sdks-alpine-release
     source: "/all-sdks-alpine/release.yaml"
+    branches:
+    - ^main$
+    - ^master$
+  - name: all-sdks-debian-release
+    source: "/all-sdks-debian/release.yaml"
     branches:
     - ^main$
     - ^master$

--- a/all-sdks-debian/Dockerfile
+++ b/all-sdks-debian/Dockerfile
@@ -1,0 +1,74 @@
+ARG GO_VERSION=1.24.4
+ARG JAVA_VERSION=17
+ARG DOTNET_VERSION=8.0
+ARG NODE_VERSION=24.13.0
+ARG NPM_VERSION=11.10.0
+ARG GRADLE_VERSION=8.13
+
+# These should be pinned to an SHA and updated by renovatebot
+FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:${GO_VERSION}-bookworm AS go-builder
+
+FROM jx3mqubebuild.azurecr.io/docker-io/library/eclipse-temurin:${JAVA_VERSION}-jdk-jammy AS java-builder
+
+FROM jx3mqubebuild.azurecr.io/mcr-microsoft-com/dotnet/sdk:${DOTNET_VERSION} AS dotnet-builder
+
+FROM jx3mqubebuild.azurecr.io/ghcr-io/astral-sh/uv:0.11.7-python3.10-trixie-slim
+
+# Re-declare ARGs for use in this stage
+ARG NODE_VERSION
+ARG NPM_VERSION
+ARG GRADLE_VERSION
+ARG JAVA_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY --from=go-builder /usr/local/go /usr/local/go
+COPY --from=java-builder /opt/java/openjdk /opt/java/openjdk
+COPY --from=dotnet-builder /usr/share/dotnet /usr/share/dotnet
+
+# wget, ca-certificates and unzip needed for image
+# All others are needed for python as we use a slim image
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        wget \
+        ca-certificates \
+        unzip \
+        xz-utils \
+        zstd \
+        gcc \
+        g++ \
+        make \
+        pkg-config \
+        linux-headers-amd64 \
+        libffi-dev \
+        libssl-dev \
+        libicu-dev \
+        zlib1g-dev \
+        freetds-dev \
+        libjpeg-dev \
+        libpng-dev \
+        libtiff-dev \
+        libwebp-dev \
+        libfreetype6-dev \
+        libgomp1 \
+        libxml2-dev \
+        libxslt1-dev
+
+# NodeJS
+RUN wget --https-only --max-redirect=0 -qO /tmp/node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+    && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
+    && rm /tmp/node.tar.xz \
+    && npm install -g "npm@${NPM_VERSION}" \
+    # Gradle
+    && wget --https-only --max-redirect=2 -q "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" -P /tmp \
+    && unzip -d /opt/gradle "/tmp/gradle-${GRADLE_VERSION}-bin.zip" \
+    && rm "/tmp/gradle-${GRADLE_VERSION}-bin.zip"
+
+ENV JAVA_HOME="/opt/java/openjdk" \
+    DOTNET_ROOT="/usr/share/dotnet" \
+    PATH="${PATH}:/usr/local/go/bin:/usr/share/dotnet:/opt/java/openjdk/bin:/opt/gradle/gradle-${GRADLE_VERSION}/bin"
+
+CMD ["/usr/bin/bash"]


### PR DESCRIPTION
### Changes
* Add Single docker image containing all SDKs

### Context
An image containing all sdks is useful for building CLIs which require target repos environments to run.
Examples include:
- rule-generator
- jx3-openapi