### PR TITLE
feat: add all-sdks-alpine image

### DIFF
--- a/.lighthouse/jenkins-x/all-sdks-alpine/pr.yaml
+++ b/.lighthouse/jenkins-x/all-sdks-alpine/pr.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: all-sdks-alpine-pr
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/pullrequest.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+          volumeMounts:
+          - mountPath: /temp-docker-config
+            name: temp-docker-config
+          env:
+          - name: IMAGE_NAME
+            value: all-sdks-alpine
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: jx-variables
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+          name: build-containers
+          resources: {}
+          script: |
+            #!/busybox/sh
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json /kaniko/.docker/config.json
+            
+            /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: push-sign-verify-containers
+          resources: {}
+          script: |
+            #!/bin/bash
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json ~/.docker/config.json
+            IMAGE_REF=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            crane push /workspace/source/$IMAGE_NAME.tar $IMAGE_REF
+            IMAGE_DIGEST=$(crane digest $IMAGE_REF)
+            IMAGE_WITH_DIGEST=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME@$IMAGE_DIGEST
+            cosign sign --yes --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            cosign verify --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            rm -f /workspace/source/$IMAGE_NAME.tar /workspace/source/scanresults.txt
+        volumes:
+        - name: temp-docker-config
+          secret:
+            secretName: tekton-temp-registry-auth
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/all-sdks-alpine/release.yaml
+++ b/.lighthouse/jenkins-x/all-sdks-alpine/release.yaml
@@ -1,0 +1,79 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: all-sdks-alpine-release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/release.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+          volumeMounts:
+          - mountPath: /temp-docker-config
+            name: temp-docker-config
+          env:
+          - name: IMAGE_NAME
+            value: all-sdks-alpine
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: next-version
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
+        - name: jx-variables
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+          name: build-containers
+          resources: {}
+          script: |
+            #!/busybox/sh
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json /kaniko/.docker/config.json
+            
+            /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: push-sign-verify-containers
+          resources: {}
+          script: |
+            #!/bin/bash
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json ~/.docker/config.json
+            
+            # Push the image using crane and get the digest
+            IMAGE_REF=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            crane push /workspace/source/$IMAGE_NAME.tar $IMAGE_REF
+            IMAGE_DIGEST=$(crane digest $IMAGE_REF)
+            IMAGE_WITH_DIGEST=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME@$IMAGE_DIGEST
+            
+            # Sign the image with cosign and verify the signature
+            cosign sign --yes --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            cosign verify --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            
+            # Retag to latest (same digest, no re-sign needed)
+            crane tag $IMAGE_REF latest
+            
+            rm -f /workspace/source/$IMAGE_NAME.tar /workspace/source/scanresults.txt
+        volumes:
+        - name: temp-docker-config
+          secret:
+            secretName: tekton-temp-registry-auth
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -6,6 +6,10 @@ spec:
     optional: false
     run_if_changed: (README.md|^.*container-tools\/.*$)
     source: "/container-tools/pr.yaml"
+  - name: all-sdks-alpine-pr
+    optional: false
+    run_if_changed: (README.md|^.*all-sdks-alpine\/.*$)
+    source: "/all-sdks-alpine/pr.yaml"
   - name: openjdk14-pr
     optional: false
     run_if_changed: (README.md|^.*openjdk14\/.*$)
@@ -93,6 +97,11 @@ spec:
     - ^master$
   - name: container-tools-release
     source: "/container-tools/release.yaml"
+    branches:
+    - ^main$
+    - ^master$
+  - name: all-sdks-alpine-release
+    source: "/all-sdks-alpine/release.yaml"
     branches:
     - ^main$
     - ^master$

--- a/all-sdks-alpine/Dockerfile
+++ b/all-sdks-alpine/Dockerfile
@@ -5,28 +5,22 @@ ARG NODE_VERSION=24
 ARG NPM_VERSION=10.9.0
 ARG GRADLE_VERSION=8.13
 
-# Stage 1: Go Builder
-FROM golang:${GO_VERSION}-alpine AS go-builder
+FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:${GO_VERSION}-alpine AS go-builder
 
-# Stage 2: Java Builder
-FROM eclipse-temurin:${JAVA_VERSION}-jdk-alpine AS java-builder
+FROM jx3mqubebuild.azurecr.io/docker-io/library/eclipse-temurin:${JAVA_VERSION}-jdk-alpine AS java-builder
 
-# Stage 3: .NET Builder
-FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-alpine AS dotnet-builder
+FROM jx3mqubebuild.azurecr.io/mcr-microsoft-com/dotnet/sdk:${DOTNET_VERSION}-alpine AS dotnet-builder
 
-# Stage 4: Your Final Base Image
-FROM ghcr.io/astral-sh/uv:python3.10-alpine
+FROM jx3mqubebuild.azurecr.io/ghcr-io/astral-sh/uv:python3.10-alpine
 
 # Re-declare NODE_VERSION ARG so we can use it in the apk step
 ARG NODE_VERSION
 
-# 2. Copy the compiled toolchains from the builder stages FIRST
+# Copy the compiled toolchains from the builder stages FIRST
 COPY --from=go-builder /usr/local/go /usr/local/go
 COPY --from=java-builder /opt/java/openjdk /opt/java/openjdk
 COPY --from=dotnet-builder /usr/share/dotnet /usr/share/dotnet
 
-# 3. Install underlying system dependencies, Node, and Python Build Tools
-# This is the heaviest step. We put it high up so it caches permanently.
 RUN apk update && apk add --no-cache \
     "nodejs~=${NODE_VERSION}" \
     npm \
@@ -55,8 +49,6 @@ RUN apk update && apk add --no-cache \
 ARG NPM_VERSION
 ARG GRADLE_VERSION
 
-# 4. Set Environment Variables and PATH
-# Moved down here! Now, changing NPM or GRADLE versions won't trigger a massive apk reinstall.
 ENV JAVA_HOME=/opt/java/openjdk \
     DOTNET_ROOT=/usr/share/dotnet \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0 \
@@ -64,7 +56,6 @@ ENV JAVA_HOME=/opt/java/openjdk \
     GRADLE_VERSION=${GRADLE_VERSION} \
     PATH="/opt/java/openjdk/bin:/usr/share/dotnet:/usr/local/go/bin:/opt/gradle/gradle-${GRADLE_VERSION}/bin:${PATH}"
 
-# 5. Pin NPM version and Install Gradle
 RUN npm install -g npm@${NPM_VERSION} \
     && wget --https-only --max-redirect=2 -q "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" -P /tmp \
     && unzip -d /opt/gradle /tmp/gradle-${GRADLE_VERSION}-bin.zip \

--- a/all-sdks-alpine/Dockerfile
+++ b/all-sdks-alpine/Dockerfile
@@ -70,6 +70,4 @@ RUN npm install -g npm@${NPM_VERSION} \
     && unzip -d /opt/gradle /tmp/gradle-${GRADLE_VERSION}-bin.zip \
     && rm /tmp/gradle-${GRADLE_VERSION}-bin.zip
 
-WORKDIR /app
-
 CMD ["/bin/sh"]

--- a/all-sdks-alpine/Dockerfile
+++ b/all-sdks-alpine/Dockerfile
@@ -66,7 +66,7 @@ ENV JAVA_HOME=/opt/java/openjdk \
 
 # 5. Pin NPM version and Install Gradle
 RUN npm install -g npm@${NPM_VERSION} \
-    && wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -P /tmp \
+    && wget --https-only --max-redirect=2 -q "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" -P /tmp \
     && unzip -d /opt/gradle /tmp/gradle-${GRADLE_VERSION}-bin.zip \
     && rm /tmp/gradle-${GRADLE_VERSION}-bin.zip
 

--- a/all-sdks-alpine/Dockerfile
+++ b/all-sdks-alpine/Dockerfile
@@ -1,0 +1,75 @@
+ARG GO_VERSION=1.23.4
+ARG JAVA_VERSION=17
+ARG DOTNET_VERSION=8.0
+ARG NODE_VERSION=24
+ARG NPM_VERSION=10.9.0
+ARG GRADLE_VERSION=8.13
+
+# Stage 1: Go Builder
+FROM golang:${GO_VERSION}-alpine AS go-builder
+
+# Stage 2: Java Builder
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-alpine AS java-builder
+
+# Stage 3: .NET Builder
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-alpine AS dotnet-builder
+
+# Stage 4: Your Final Base Image
+FROM ghcr.io/astral-sh/uv:python3.10-alpine
+
+# Re-declare NODE_VERSION ARG so we can use it in the apk step
+ARG NODE_VERSION
+
+# 2. Copy the compiled toolchains from the builder stages FIRST
+COPY --from=go-builder /usr/local/go /usr/local/go
+COPY --from=java-builder /opt/java/openjdk /opt/java/openjdk
+COPY --from=dotnet-builder /usr/share/dotnet /usr/share/dotnet
+
+# 3. Install underlying system dependencies, Node, and Python Build Tools
+# This is the heaviest step. We put it high up so it caches permanently.
+RUN apk update && apk add --no-cache \
+    "nodejs~=${NODE_VERSION}" \
+    npm \
+    libstdc++ \
+    libgcc \
+    zlib \
+    tzdata \
+    icu-libs \
+    build-base \
+    python3-dev \
+    musl-dev \
+    linux-headers \
+    libffi-dev \
+    openssl-dev \
+    freetds-dev \
+    openblas-dev \
+    gfortran \
+    jpeg-dev \
+    zlib-dev \
+    freetype-dev \
+    tiff-dev \
+    wget \
+    unzip
+
+# Re-declare remaining ARGs before using them in ENVs
+ARG NPM_VERSION
+ARG GRADLE_VERSION
+
+# 4. Set Environment Variables and PATH
+# Moved down here! Now, changing NPM or GRADLE versions won't trigger a massive apk reinstall.
+ENV JAVA_HOME=/opt/java/openjdk \
+    DOTNET_ROOT=/usr/share/dotnet \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=0 \
+    NPM_VERSION=${NPM_VERSION} \
+    GRADLE_VERSION=${GRADLE_VERSION} \
+    PATH="/opt/java/openjdk/bin:/usr/share/dotnet:/usr/local/go/bin:/opt/gradle/gradle-${GRADLE_VERSION}/bin:${PATH}"
+
+# 5. Pin NPM version and Install Gradle
+RUN npm install -g npm@${NPM_VERSION} \
+    && wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -P /tmp \
+    && unzip -d /opt/gradle /tmp/gradle-${GRADLE_VERSION}-bin.zip \
+    && rm /tmp/gradle-${GRADLE_VERSION}-bin.zip
+
+WORKDIR /app
+
+CMD ["/bin/sh"]

--- a/all-sdks-alpine/Dockerfile
+++ b/all-sdks-alpine/Dockerfile
@@ -1,3 +1,5 @@
+# We've added python/uv for completion
+# However, we recommend using Debian
 ARG GO_VERSION=1.23.4
 ARG JAVA_VERSION=17
 ARG DOTNET_VERSION=8.0
@@ -5,6 +7,7 @@ ARG NODE_VERSION=24
 ARG NPM_VERSION=10.9.0
 ARG GRADLE_VERSION=8.13
 
+# These should be pinned to an SHA and updated by renovatebot
 FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:${GO_VERSION}-alpine AS go-builder
 
 FROM jx3mqubebuild.azurecr.io/docker-io/library/eclipse-temurin:${JAVA_VERSION}-jdk-alpine AS java-builder


### PR DESCRIPTION
### Changes
* Add Single docker image containing all SDKs

### Context
An image containing all sdks is useful for building CLIs which require target repos environments to run.
This is the alpine version.
Examples include:
- rule-generator
- jx3-openapi