### PR TITLE
chore: Update torch Docker images

### DIFF
--- a/python310-torch-cpu/Dockerfile
+++ b/python310-torch-cpu/Dockerfile
@@ -1,12 +1,10 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/ubuntu:22.04
-RUN apt update \
-    && DEBIAN_FRONTEND=noninteractive apt install -y git libglib2.0-0 libsm6 libxrender1 libxext6 libexpat1-dev libpython3-dev python3-dev python3 python3-distutils wget curl ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN ln -s /usr/bin/pydoc3 /usr/local/bin/pydoc \
-    && ln -s /usr/bin/python3 /usr/local/bin/python \
-    && ln -s /usr/bin/python3-config /usr/local/bin/python-config \
-    && python get-pip.py
-RUN apt-get update && apt-get -y install gcc make git gfortran libopenblas-dev liblapack-dev poppler-utils libgl1-mesa-dev
-RUN python3 -m pip install uv torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cpu
+FROM jx3mqubebuild.azurecr.io/spring-financial-group/python310:latest
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gfortran \
+        libgl1-mesa-dev \
+        liblapack-dev \
+        libopenblas-dev \
+        poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
 CMD ["bash"]

--- a/python310-torch-cuda/Dockerfile
+++ b/python310-torch-cuda/Dockerfile
@@ -1,12 +1,38 @@
 FROM jx3mqubebuild.azurecr.io/docker-io/nvidia/cuda:11.7.1-base-ubuntu22.04
-RUN apt update \
-    && DEBIAN_FRONTEND=noninteractive apt install -y git libglib2.0-0 libsm6 libxrender1 libxext6 libexpat1-dev libpython3-dev python3-dev python3 python3-distutils wget curl ca-certificates \
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gcc \
+        gfortran \
+        git \
+        libexpat1-dev \
+        libgl1-mesa-dev \
+        libglib2.0-0 \
+        liblapack-dev \
+        libopenblas-dev \
+        libpython3-dev \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+        make \
+        poppler-utils \
+        python3 \
+        python3-dev \
+        python3-distutils \
+        wget \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq &&\
+    chmod +x /usr/bin/yq
+
 RUN ln -s /usr/bin/pydoc3 /usr/local/bin/pydoc \
     && ln -s /usr/bin/python3 /usr/local/bin/python \
     && ln -s /usr/bin/python3-config /usr/local/bin/python-config \
     && python get-pip.py
-RUN apt-get update && apt-get -y install gcc make git gfortran libopenblas-dev liblapack-dev poppler-utils libgl1-mesa-dev
-RUN python3 -m pip install uv torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1
+RUN pip install --upgrade pip \
+    && pip install --upgrade setuptools \
+    && pip install uv
 CMD ["bash"]


### PR DESCRIPTION
### Changes
* python310-torch-cpu built on top of python310 base image
* python310-torch-cuda follows the same commands as python310
* Remove torch install from base image

### Context
Torch being stuck to a single version in the base image is not ideal.
Let services handle their own torch versions.