### PR TITLE
chore: bump golang version to 1.26 in golang-chromium Dockerfile

### DIFF
--- a/golang-chromium/Dockerfile
+++ b/golang-chromium/Dockerfile
@@ -1,4 +1,4 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:1.24
+FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:1.26
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends chromium \


### PR DESCRIPTION
### Changes
- bump go to 1.26 in golang-chromium

### Context
This version of Golang, 1.24, is no longer supported. Only the latest two versions are available.
I believe DocGen is the only service reliant on this so it is acceptable.