### PR TITLE
fix: python 314 dependencies

### DIFF
--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -37,6 +37,7 @@ spec:
   - name: python314-pr
     optional: false
     run_if_changed: (README.md|^.*python314\/.*$)
+    source: "/python314/pr.yaml"
   - name: nginx-pr
     optional: false
     run_if_changed: (README.md|^.*nginx\/.*$)

--- a/python314/Dockerfile
+++ b/python314/Dockerfile
@@ -16,3 +16,12 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt update \
     && apt install gh -y
+
+RUN apt-get update && apt-get install -y \
+    libxcb1 \
+    libx11-6 \
+    libxext6 \
+    libxrender1 \
+    libgl1 \
+    libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Changes

- Python dependencies needed by pytorch repos

### Context

I hate split images one for cuda one for non cuda. So i'm just putting this into one image. Its low overhead and maximum compatibility 💪🏻 

Tested here: https://github.com/spring-financial-group/mqube-recogniser-template/pull/701 (openapi check)