### PR TITLE
chore: install gcc in python 314 img

### DIFF
--- a/python314/Dockerfile
+++ b/python314/Dockerfile
@@ -1,6 +1,6 @@
 FROM jx3mqubebuild.azurecr.io/ghcr-io/astral-sh/uv:0.11.19-debian-slim
 
-RUN apt update && apt install -y --no-install-recommends wget make git ca-certificates
+RUN apt update && apt install -y --no-install-recommends wget make git ca-certificates gcc
 
 ARG YQ_VERSION=v4.53.3
 ARG YQ_BINARY=yq_linux_amd64


### PR DESCRIPTION
### Changes
* Add GCC to installed pkgs in python 314 image

### Context
GCC is required for numpy pkgs