### PR TITLE
feat: docksec base container image

### DIFF
--- a/.lighthouse/jenkins-x/docksec/pr.yaml
+++ b/.lighthouse/jenkins-x/docksec/pr.yaml
@@ -45,7 +45,7 @@ spec:
             #!/bin/sh
             mkdir -p ~/.cache/trivy/db
             mv /trivydb/* ~/.cache/trivy/db/
-        - image: jx3mqubebuild.azurecr.io/docker-io/aquasec/trivy:0.53.0
+        - image: jx3mqubebuild.azurecr.io/docker-io/aquasec/trivy:0.73.0
           name: vulnscan
           resources: {}
           script: |

--- a/.lighthouse/jenkins-x/docksec/pr.yaml
+++ b/.lighthouse/jenkins-x/docksec/pr.yaml
@@ -49,7 +49,7 @@ spec:
           name: vulnscan
           resources: {}
           script: |
-            trivy image --timeout 25m0s --security-checks vuln --ignore-unfixed --input /workspace/source/$IMAGE_NAME.tar | tee /workspace/source/scanresults.txt
+            trivy image --timeout 25m0s --security-checks vuln --ignore-unfixed --ignorefile /workspace/source/$IMAGE_NAME/.trivyignore.yaml --input /workspace/source/$IMAGE_NAME.tar | tee /workspace/source/scanresults.txt
         - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
           name: analyze
           resources: {}

--- a/.lighthouse/jenkins-x/docksec/pr.yaml
+++ b/.lighthouse/jenkins-x/docksec/pr.yaml
@@ -49,7 +49,7 @@ spec:
           name: vulnscan
           resources: {}
           script: |
-            trivy image --timeout 25m0s --security-checks vuln --input /workspace/source/$IMAGE_NAME.tar | tee /workspace/source/scanresults.txt
+            trivy image --timeout 25m0s --security-checks vuln --ignore-unfixed --input /workspace/source/$IMAGE_NAME.tar | tee /workspace/source/scanresults.txt
         - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
           name: analyze
           resources: {}

--- a/.lighthouse/jenkins-x/docksec/pr.yaml
+++ b/.lighthouse/jenkins-x/docksec/pr.yaml
@@ -1,0 +1,98 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: docksec-pr
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/pullrequest.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+          volumeMounts:
+          - mountPath: /temp-docker-config
+            name: temp-docker-config
+          env:
+          - name: IMAGE_NAME
+            value: docksec
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: jx-variables
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+          name: build-containers
+          resources: {}
+          script: |
+            #!/busybox/sh
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json /kaniko/.docker/config.json
+
+            /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: ghcr.io/jenkins-x/trivydb:latest
+          name: copy-vulns-db
+          resources: {}
+          script: |
+            #!/bin/sh
+            mkdir -p ~/.cache/trivy/db
+            mv /trivydb/* ~/.cache/trivy/db/
+        - image: jx3mqubebuild.azurecr.io/docker-io/aquasec/trivy:0.53.0
+          name: vulnscan
+          resources: {}
+          script: |
+            trivy image --timeout 25m0s --security-checks vuln --input /workspace/source/$IMAGE_NAME.tar | tee /workspace/source/scanresults.txt
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: analyze
+          resources: {}
+          script: |
+            #!/bin/bash
+            SLACK_WEBHOOK_URL=$(kubectl get secret slack -n jx -o jsonpath="{.data['sec-alerts-webhook']}" | base64 -d)
+            PIPELINE_NAME=$(context.pipeline.name)
+            PIPELINE_RUN_NAMESPACE=$(context.pipelineRun.namespace)
+            TEKTON_URL=https://tekton-dashboard.jx.mqube.build/#/namespaces/$PIPELINE_RUN_NAMESPACE/pipelineruns/$PIPELINE_NAME
+            PR_URL=${REPO_URL%.git}/pull/$PULL_NUMBER
+
+            source .jx/variables.sh
+            cat /workspace/source/scanresults.txt
+            if egrep 'HIGH|CRITICAL' /workspace/source/scanresults.txt | grep -v 'Total' | grep -v 'guests via high...' | grep -v "numpy" | grep -v "linux-libc-dev" | grep -v 'vulnerability leads to critical' | grep -v 'python'
+            then
+            echo "VULNERABILITIES found!" && curl -s -X POST --data-urlencode "payload={\"channel\": \"#alerts-security\", \"username\": \"secalerts\", \"text\": \"HIGH/CRITICAL VULNERABILITY FOUND in $APP_NAME:$VERSION\n• Build stopped at <$PR_URL|PR#$PULL_NUMBER>\n• Logs available <$TEKTON_URL|here>\", \"icon_emoji\": \":shield:\"}" "$SLACK_WEBHOOK_URL" > /dev/null
+            exit 1
+            else
+            echo "EVERYTHING IS OK"
+            fi
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: push-sign-verify-containers
+          resources: {}
+          script: |
+            #!/bin/bash
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json ~/.docker/config.json
+            IMAGE_REF=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            crane push /workspace/source/$IMAGE_NAME.tar $IMAGE_REF
+            IMAGE_DIGEST=$(crane digest $IMAGE_REF)
+            IMAGE_WITH_DIGEST=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME@$IMAGE_DIGEST
+            cosign sign --yes --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            cosign verify --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            rm -f /workspace/source/$IMAGE_NAME.tar /workspace/source/scanresults.txt
+        volumes:
+        - name: temp-docker-config
+          secret:
+            secretName: tekton-temp-registry-auth
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/docksec/release.yaml
+++ b/.lighthouse/jenkins-x/docksec/release.yaml
@@ -1,0 +1,79 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: docksec-release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/release.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+          volumeMounts:
+          - mountPath: /temp-docker-config
+            name: temp-docker-config
+          env:
+          - name: IMAGE_NAME
+            value: docksec
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: next-version
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
+        - name: jx-variables
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+          name: build-containers
+          resources: {}
+          script: |
+            #!/busybox/sh
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json /kaniko/.docker/config.json
+
+            /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: push-sign-verify-containers
+          resources: {}
+          script: |
+            #!/bin/bash
+            set -e
+            source .jx/variables.sh
+            cp /temp-docker-config/config.json ~/.docker/config.json
+
+            # Push the image using crane and get the digest
+            IMAGE_REF=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
+            crane push /workspace/source/$IMAGE_NAME.tar $IMAGE_REF
+            IMAGE_DIGEST=$(crane digest $IMAGE_REF)
+            IMAGE_WITH_DIGEST=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME@$IMAGE_DIGEST
+
+            # Sign the image with cosign and verify the signature
+            cosign sign --yes --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            cosign verify --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+
+            # Retag to latest (same digest, no re-sign needed)
+            crane tag $IMAGE_REF latest
+
+            rm -f /workspace/source/$IMAGE_NAME.tar /workspace/source/scanresults.txt
+        volumes:
+        - name: temp-docker-config
+          secret:
+            secretName: tekton-temp-registry-auth
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -6,6 +6,10 @@ spec:
     optional: false
     run_if_changed: (README.md|^.*container-tools\/.*$)
     source: "/container-tools/pr.yaml"
+  - name: docksec-pr
+    optional: false
+    run_if_changed: (README.md|^.*docksec\/.*$)
+    source: "/docksec/pr.yaml"
   - name: all-sdks-alpine-pr
     optional: false
     run_if_changed: (README.md|^.*all-sdks-alpine\/.*$)
@@ -105,6 +109,11 @@ spec:
     - ^master$
   - name: container-tools-release
     source: "/container-tools/release.yaml"
+    branches:
+    - ^main$
+    - ^master$
+  - name: docksec-release
+    source: "/docksec/release.yaml"
     branches:
     - ^main$
     - ^master$

--- a/docksec/.trivyignore.yaml
+++ b/docksec/.trivyignore.yaml
@@ -1,0 +1,4 @@
+vulnerabilities:
+  # CVE-2026-50163 (oras-go v2.6.1) - trivy has a dependencybot PR merging as I'm typing this
+  - id: CVE-2026-50163
+    expired_at: 2026-08-31

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -30,6 +30,10 @@ RUN mkdir -p /opt/tools \
 
 FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie
 
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /opt/docksec-venv /opt/docksec-venv
 COPY --from=builder /opt/tools/ /usr/local/bin/
 

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -1,4 +1,4 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-bookworm AS builder
+FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie AS builder
 
 ARG DOCKSEC_VERSION=2026.7.5
 
@@ -16,7 +16,7 @@ RUN pip install --no-cache-dir \
     "docksec[ai]==${DOCKSEC_VERSION}"
 
 
-FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-bookworm
+FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie
 
 ARG TRIVY_VERSION=0.73.0
 ARG HADOLINT_VERSION=2.12.0

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -6,8 +6,6 @@ ARG HADOLINT_VERSION=2.12.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        gcc \
-        make \
         ca-certificates \
         curl \
     && rm -rf /var/lib/apt/lists/*
@@ -31,8 +29,6 @@ RUN mkdir -p /opt/tools \
     && chmod +x /opt/tools/hadolint
 
 FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie
-
-RUN apt-get update
 
 COPY --from=builder /opt/docksec-venv /opt/docksec-venv
 COPY --from=builder /opt/tools/ /usr/local/bin/

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -1,11 +1,15 @@
 FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie AS builder
 
 ARG DOCKSEC_VERSION=2026.7.5
+ARG TRIVY_VERSION=0.73.0
+ARG HADOLINT_VERSION=2.12.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         gcc \
         make \
+        ca-certificates \
+        curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m venv /opt/docksec-venv
@@ -15,16 +19,23 @@ ENV PATH="/opt/docksec-venv/bin:${PATH}"
 RUN pip install --no-cache-dir \
     "docksec[ai]==${DOCKSEC_VERSION}"
 
+RUN mkdir -p /opt/tools \
+    && curl -fsSL \
+         "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+         -o /tmp/trivy.tar.gz \
+    && tar -xzf /tmp/trivy.tar.gz -C /opt/tools trivy \
+    && rm /tmp/trivy.tar.gz \
+    && curl -fsSL \
+         "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
+         -o /opt/tools/hadolint \
+    && chmod +x /opt/tools/hadolint
+
 
 FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie
-
-ARG TRIVY_VERSION=0.73.0
-ARG HADOLINT_VERSION=2.12.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
-        curl \
         git \
         jq \
         libxcb1 \
@@ -36,19 +47,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/docksec-venv /opt/docksec-venv
+COPY --from=builder /opt/tools/ /usr/local/bin/
 
 ENV PATH="/opt/docksec-venv/bin:/usr/local/bin:${PATH}"
 ENV HOME=/tekton/home
-
-RUN curl -fsSL \
-      "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
-      -o /tmp/trivy.tar.gz \
-    && tar -xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy \
-    && rm /tmp/trivy.tar.gz
-
-RUN curl -fsSL \
-      "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
-      -o /usr/local/bin/hadolint \
-    && chmod +x /usr/local/bin/hadolint
 
 WORKDIR /workspace/source

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -30,21 +30,9 @@ RUN mkdir -p /opt/tools \
          -o /opt/tools/hadolint \
     && chmod +x /opt/tools/hadolint
 
-
 FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        git \
-        jq \
-        libxcb1 \
-        libx11-6 \
-        libxext6 \
-        libxrender1 \
-        libgl1 \
-        libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update
 
 COPY --from=builder /opt/docksec-venv /opt/docksec-venv
 COPY --from=builder /opt/tools/ /usr/local/bin/

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -1,0 +1,54 @@
+FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-bookworm AS builder
+
+ARG DOCKSEC_VERSION=2026.7.5
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gcc \
+        make \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m venv /opt/docksec-venv
+
+ENV PATH="/opt/docksec-venv/bin:${PATH}"
+
+RUN pip install --no-cache-dir \
+    "docksec[ai]==${DOCKSEC_VERSION}"
+
+
+FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-bookworm
+
+ARG TRIVY_VERSION=0.73.0
+ARG HADOLINT_VERSION=2.12.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        libxcb1 \
+        libx11-6 \
+        libxext6 \
+        libxrender1 \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/docksec-venv /opt/docksec-venv
+
+ENV PATH="/opt/docksec-venv/bin:/usr/local/bin:${PATH}"
+ENV HOME=/tekton/home
+
+RUN curl -fsSL \
+      "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+      -o /tmp/trivy.tar.gz \
+    && tar -xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy \
+    && rm /tmp/trivy.tar.gz
+
+RUN curl -fsSL \
+      "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
+      -o /usr/local/bin/hadolint \
+    && chmod +x /usr/local/bin/hadolint
+
+WORKDIR /workspace/source


### PR DESCRIPTION
I've created a new base img I can use from within the pipeline catalogue to trigger Docksec - Installing all of the required dependencies such as trivy and halolint.

The base of this is the slim debian image that is installed with python, as you have to use pip to install Docksec.

Idk if there's a better way to do this, so let me know if there is 