### PR TITLE
chore: install docker into docksec image

### DIFF
--- a/docksec/.trivyignore.yaml
+++ b/docksec/.trivyignore.yaml
@@ -2,7 +2,8 @@ vulnerabilities:
   # CVE-2026-50163 (oras-go v2.6.1) - trivy has a dependencybot PR merging as I'm typing this
   - id: CVE-2026-50163
     expired_at: 2026-08-31
-  # due to Python (transitive deps pulled in by docksec[ai]):
-  # GHSA-6v7p-g79w-8964 (msgpack, via langchain) - https://github.com/OWASP/DockSec/pull/93
+  # due to Python (transitive deps pulled in by docksec[ai]): https://github.com/OWASP/DockSec/pull/93
   - id: GHSA-6v7p-g79w-8964
+    expired_at: 2026-09-30
+  - id: CVE-2025-47273
     expired_at: 2026-09-30

--- a/docksec/.trivyignore.yaml
+++ b/docksec/.trivyignore.yaml
@@ -2,3 +2,7 @@ vulnerabilities:
   # CVE-2026-50163 (oras-go v2.6.1) - trivy has a dependencybot PR merging as I'm typing this
   - id: CVE-2026-50163
     expired_at: 2026-08-31
+  # due to Python (transitive deps pulled in by docksec[ai]):
+  # GHSA-6v7p-g79w-8964 (msgpack, via langchain) - https://github.com/OWASP/DockSec/pull/93
+  - id: GHSA-6v7p-g79w-8964
+    expired_at: 2026-09-30

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -3,6 +3,7 @@ FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie AS build
 ARG DOCKSEC_VERSION=2026.7.5
 ARG TRIVY_VERSION=0.73.0
 ARG HADOLINT_VERSION=2.12.0
+ARG DOCKER_VERSION=27.5.1
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -22,11 +23,16 @@ RUN mkdir -p /opt/tools \
          "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
          -o /tmp/trivy.tar.gz \
     && tar -xzf /tmp/trivy.tar.gz -C /opt/tools trivy \
-    && rm /tmp/trivy.tar.gz \
-    && curl -fsSL \
+    && rm /tmp/trivy.tar.gz
+
+RUN curl -fsSL \
          "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
          -o /opt/tools/hadolint \
     && chmod +x /opt/tools/hadolint
+
+RUN ARCH=$(uname -m) \
+    && curl -fsSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz" \
+         | tar xz -C /opt/tools --strip-components=1 docker/docker
 
 FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie
 

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -2,11 +2,8 @@ FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie AS build
 
 ARG DOCKSEC_VERSION=2026.7.5
 ARG TRIVY_VERSION=0.73.0
-ARG TRIVY_SHA256=2edd39da482bb4e9831962487b68f68e3928ec3137794757f54d00383d79547b
 ARG HADOLINT_VERSION=2.12.0
-ARG HADOLINT_SHA256=56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010
 ARG DOCKER_VERSION=29.7.1
-ARG DOCKER_SHA256=0fcea2a8b4d1b54ccc9010e3451b78504a369d414f37eb3bb79300e1b5c22ce6
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -25,19 +22,16 @@ RUN mkdir -p /opt/tools \
     && curl -fsSL \
          "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
          -o /tmp/trivy.tar.gz \
-    && echo "${TRIVY_SHA256}  /tmp/trivy.tar.gz" | sha256sum -c - \
     && tar -xzf /tmp/trivy.tar.gz -C /opt/tools trivy \
     && rm /tmp/trivy.tar.gz
 
 RUN curl -fsSL \
          "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
          -o /opt/tools/hadolint \
-    && echo "${HADOLINT_SHA256}  /opt/tools/hadolint" | sha256sum -c - \
     && chmod +x /opt/tools/hadolint
 
 RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
          -o /tmp/docker.tgz \
-    && echo "${DOCKER_SHA256}  /tmp/docker.tgz" | sha256sum -c - \
     && tar -xzf /tmp/docker.tgz -C /opt/tools --strip-components=1 docker/docker \
     && rm /tmp/docker.tgz
 

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -3,7 +3,7 @@ FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie AS build
 ARG DOCKSEC_VERSION=2026.7.5
 ARG TRIVY_VERSION=0.73.0
 ARG HADOLINT_VERSION=2.12.0
-ARG DOCKER_VERSION=27.5.1
+ARG DOCKER_VERSION=29.7.1
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -2,8 +2,11 @@ FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie AS build
 
 ARG DOCKSEC_VERSION=2026.7.5
 ARG TRIVY_VERSION=0.73.0
+ARG TRIVY_SHA256=2edd39da482bb4e9831962487b68f68e3928ec3137794757f54d00383d79547b
 ARG HADOLINT_VERSION=2.12.0
+ARG HADOLINT_SHA256=56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010
 ARG DOCKER_VERSION=29.7.1
+ARG DOCKER_SHA256=0fcea2a8b4d1b54ccc9010e3451b78504a369d414f37eb3bb79300e1b5c22ce6
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -22,17 +25,21 @@ RUN mkdir -p /opt/tools \
     && curl -fsSL \
          "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
          -o /tmp/trivy.tar.gz \
+    && echo "${TRIVY_SHA256}  /tmp/trivy.tar.gz" | sha256sum -c - \
     && tar -xzf /tmp/trivy.tar.gz -C /opt/tools trivy \
     && rm /tmp/trivy.tar.gz
 
 RUN curl -fsSL \
          "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
          -o /opt/tools/hadolint \
+    && echo "${HADOLINT_SHA256}  /opt/tools/hadolint" | sha256sum -c - \
     && chmod +x /opt/tools/hadolint
 
-RUN ARCH=$(uname -m) \
-    && curl -fsSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz" \
-         | tar xz -C /opt/tools --strip-components=1 docker/docker
+RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
+         -o /tmp/docker.tgz \
+    && echo "${DOCKER_SHA256}  /tmp/docker.tgz" | sha256sum -c - \
+    && tar xz -C /opt/tools --strip-components=1 docker/docker \
+    && rm /tmp/docker.tgz
 
 FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie
 

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -38,7 +38,7 @@ RUN curl -fsSL \
 RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
          -o /tmp/docker.tgz \
     && echo "${DOCKER_SHA256}  /tmp/docker.tgz" | sha256sum -c - \
-    && tar xz -C /opt/tools --strip-components=1 docker/docker \
+    && tar -xzf /tmp/docker.tgz -C /opt/tools --strip-components=1 docker/docker \
     && rm /tmp/docker.tgz
 
 FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie


### PR DESCRIPTION
This is the new base image I created to run the docksec pipelines, as at the moment there is no official docker image.

Installing docker in the docker container so I can use docker in docker (DiD) using a sidecar. This is because Docksec requires Docker to run the Docker Scout tool.