### PR TITLE
feat: use alpine in node base image

### DIFF
--- a/.lighthouse/jenkins-x/node/pr.yaml
+++ b/.lighthouse/jenkins-x/node/pr.yaml
@@ -38,6 +38,38 @@ spec:
             cp /temp-docker-config/config.json /kaniko/.docker/config.json
 
             /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: ghcr.io/jenkins-x/trivydb:latest
+          name: copy-vulns-db
+          resources: {}
+          script: |
+            #!/bin/sh
+            mkdir -p ~/.cache/trivy/db
+            mv /trivydb/* ~/.cache/trivy/db/
+        - image: jx3mqubebuild.azurecr.io/docker-io/aquasec/trivy:0.73.0
+          name: vulnscan
+          resources: {}
+          script: |
+            trivy image --timeout 25m0s --security-checks vuln --ignore-unfixed --ignorefile /workspace/source/$IMAGE_NAME/.trivyignore.yaml --input /workspace/source/$IMAGE_NAME.tar | tee /workspace/source/scanresults.txt
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: analyze
+          resources: {}
+          script: |
+            #!/bin/bash
+            SLACK_WEBHOOK_URL=$(kubectl get secret slack -n jx -o jsonpath="{.data['sec-alerts-webhook']}" | base64 -d)
+            PIPELINE_NAME=$(context.pipeline.name)
+            PIPELINE_RUN_NAMESPACE=$(context.pipelineRun.namespace)
+            TEKTON_URL=https://tekton-dashboard.jx.mqube.build/#/namespaces/$PIPELINE_RUN_NAMESPACE/pipelineruns/$PIPELINE_NAME
+            PR_URL=${REPO_URL%.git}/pull/$PULL_NUMBER
+
+            source .jx/variables.sh
+            cat /workspace/source/scanresults.txt
+            if egrep 'HIGH|CRITICAL' /workspace/source/scanresults.txt | grep -v 'Total' | grep -v 'guests via high...' | grep -v "numpy" | grep -v "linux-libc-dev" | grep -v 'vulnerability leads to critical' | grep -v 'python'
+            then
+            echo "VULNERABILITIES found!" && curl -s -X POST --data-urlencode "payload={\"channel\": \"#alerts-security\", \"username\": \"secalerts\", \"text\": \"HIGH/CRITICAL VULNERABILITY FOUND in $APP_NAME:$VERSION\n• Build stopped at <$PR_URL|PR#$PULL_NUMBER>\n• Logs available <$TEKTON_URL|here>\", \"icon_emoji\": \":shield:\"}" "$SLACK_WEBHOOK_URL" > /dev/null
+            exit 1
+            else
+            echo "EVERYTHING IS OK"
+            fi
         - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
           name: push-sign-verify-containers
           resources: {}

--- a/node-unit-test/Dockerfile
+++ b/node-unit-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.13
+FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.13-alpine
 
 # Setting npm version on it's own line to avoid issues with it updating itself
 RUN npm install -g npm@11.10.0
@@ -22,4 +22,4 @@ RUN npm install -g \
         libgbm1 \
         libasound2
 
-CMD ["bash"]
+CMD ["/bin/sh"]

--- a/node-unit-test/Dockerfile
+++ b/node-unit-test/Dockerfile
@@ -1,4 +1,5 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.13-alpine
+# Playwright on Alpine is still experimental, so we will use a Debian-based image for now. See https://playwright.dev/docs/intro#running-on-alpine-linux for more information.
+FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.13
 
 # Setting npm version on it's own line to avoid issues with it updating itself
 RUN npm install -g npm@11.10.0
@@ -22,4 +23,4 @@ RUN npm install -g \
         libgbm1 \
         libasound2
 
-CMD ["/bin/sh"]
+CMD ["bash"]

--- a/node/.trivyignore.yaml
+++ b/node/.trivyignore.yaml
@@ -1,0 +1,1 @@
+vulnerabilities: []

--- a/node/.trivyignore.yaml
+++ b/node/.trivyignore.yaml
@@ -6,5 +6,3 @@ vulnerabilities:
 # brace-expansion
 - id: CVE-2026-14257
   expired_at: 2026-12-31
-
-

--- a/node/.trivyignore.yaml
+++ b/node/.trivyignore.yaml
@@ -1,8 +1,12 @@
 # These vulnerabilities shouldn't be an issue with Angular22, but we are currently on 20
+# (Current angular version is incompatible with later typescript versions)
 vulnerabilities:
 # @hono/node-server
 - id: GHSA-frvp-7c67-39w9
   expired_at: 2026-12-31
 # brace-expansion
 - id: CVE-2026-14257
+  expired_at: 2026-12-31
+# brace-expansion and ip-address
+- id: CVE-2026-69152
   expired_at: 2026-12-31

--- a/node/.trivyignore.yaml
+++ b/node/.trivyignore.yaml
@@ -1,1 +1,5 @@
-vulnerabilities: []
+vulnerabilities:
+  # @hono/node-server - Fixed in later angular versions, but UI is still stuck on v20
+  - id: GHSA-frvp-7c67-39w9
+    expired_at: 2026-12-31
+

--- a/node/.trivyignore.yaml
+++ b/node/.trivyignore.yaml
@@ -10,3 +10,6 @@ vulnerabilities:
 # brace-expansion and ip-address
 - id: CVE-2026-69152
   expired_at: 2026-12-31
+# ip-address
+- id: CVE-2026-69192
+  expired_at: 2026-12-31

--- a/node/.trivyignore.yaml
+++ b/node/.trivyignore.yaml
@@ -1,5 +1,10 @@
+# These vulnerabilities shouldn't be an issue with Angular22, but we are currently on 20
 vulnerabilities:
-  # @hono/node-server - Fixed in later angular versions, but UI is still stuck on v20
-  - id: GHSA-frvp-7c67-39w9
-    expired_at: 2026-12-31
+# @hono/node-server
+- id: GHSA-frvp-7c67-39w9
+  expired_at: 2026-12-31
+# brace-expansion
+- id: CVE-2026-14257
+  expired_at: 2026-12-31
+
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,5 +1,5 @@
 FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.19-alpine
 
-RUN npm install -g npm@12.0.2 @angular/cli@20.3 @angular/compiler-cli@20.3 typescript@7.0.2
+RUN npm install -g npm@11.19.0 @angular/cli@20.3 @angular/compiler-cli@20.3 typescript@5.8
 
 CMD ["/bin/sh"]

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,5 +1,7 @@
 FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.13-alpine
 
-RUN npm install -g npm@11.10.0 @angular/cli@20.3 @angular/compiler-cli@20.3 typescript@5.8
+RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk
+
+RUN npm install -g npm@11.19.0 @angular/cli@20.3 @angular/compiler-cli@20.3 typescript@5.8
 
 CMD ["/bin/sh"]

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,5 +1,5 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.13
+FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.13-alpine
 
 RUN npm install -g npm@11.10.0 @angular/cli@20.3 @angular/compiler-cli@20.3 typescript@5.8
 
-CMD ["bash"]
+CMD ["/bin/sh"]

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,5 +1,5 @@
 FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.19-alpine
 
-RUN npm install -g npm@11.19.0 @angular/cli@20.3 @angular/compiler-cli@20.3 typescript@5.8
+RUN npm install -g npm@12.0.2 @angular/cli@20.3 @angular/compiler-cli@20.3 typescript@7.0.2
 
 CMD ["/bin/sh"]

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,6 +1,4 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.13-alpine
-
-RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk
+FROM jx3mqubebuild.azurecr.io/docker-io/library/node:24.19-alpine
 
 RUN npm install -g npm@11.19.0 @angular/cli@20.3 @angular/compiler-cli@20.3 typescript@5.8
 


### PR DESCRIPTION
### Changes
This change reduces Vulnerabilities by 160 when using the node image as a runtime container by opting for Alpine which does not have a lot of runtime dependencies, passing the analysis step.

Alpine does not ship with bash, which is why I have replaced the entrypoint to use SH instead.

This hasn't been picked up on frontend PRs as this step is only used as a builder in the UI repos, and the runtime container is instead nginx. However, we have a couple JS projects that use this container (blockchain stuff mainly)

Example repo using this at runtime (network-of-oracles)
<img width="698" height="332" alt="image" src="https://github.com/user-attachments/assets/6087669c-75d8-4084-902a-648c3427b1b1" />
