### PR TITLE
feat: add trivy step to python 3.14 images and resolve vulns

### DIFF
--- a/.lighthouse/jenkins-x/python314/pr.yaml
+++ b/.lighthouse/jenkins-x/python314/pr.yaml
@@ -38,6 +38,38 @@ spec:
             cp /temp-docker-config/config.json /kaniko/.docker/config.json
 
             /kaniko/executor $KANIKO_FLAGS --cleanup --context=/workspace/source/$IMAGE_NAME --dockerfile="Dockerfile" --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION --no-push --tarPath $IMAGE_NAME.tar
+        - image: ghcr.io/jenkins-x/trivydb:latest
+          name: copy-vulns-db
+          resources: {}
+          script: |
+            #!/bin/sh
+            mkdir -p ~/.cache/trivy/db
+            mv /trivydb/* ~/.cache/trivy/db/
+        - image: jx3mqubebuild.azurecr.io/docker-io/aquasec/trivy:0.73.0
+          name: vulnscan
+          resources: {}
+          script: |
+            trivy image --timeout 25m0s --security-checks vuln --ignore-unfixed --ignorefile /workspace/source/$IMAGE_NAME/.trivyignore.yaml --input /workspace/source/$IMAGE_NAME.tar | tee /workspace/source/scanresults.txt
+        - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
+          name: analyze
+          resources: {}
+          script: |
+            #!/bin/bash
+            SLACK_WEBHOOK_URL=$(kubectl get secret slack -n jx -o jsonpath="{.data['sec-alerts-webhook']}" | base64 -d)
+            PIPELINE_NAME=$(context.pipeline.name)
+            PIPELINE_RUN_NAMESPACE=$(context.pipelineRun.namespace)
+            TEKTON_URL=https://tekton-dashboard.jx.mqube.build/#/namespaces/$PIPELINE_RUN_NAMESPACE/pipelineruns/$PIPELINE_NAME
+            PR_URL=${REPO_URL%.git}/pull/$PULL_NUMBER
+
+            source .jx/variables.sh
+            cat /workspace/source/scanresults.txt
+            if egrep 'HIGH|CRITICAL' /workspace/source/scanresults.txt | grep -v 'Total' | grep -v 'guests via high...' | grep -v "numpy" | grep -v "linux-libc-dev" | grep -v 'vulnerability leads to critical' | grep -v 'python'
+            then
+            echo "VULNERABILITIES found!" && curl -s -X POST --data-urlencode "payload={\"channel\": \"#alerts-security\", \"username\": \"secalerts\", \"text\": \"HIGH/CRITICAL VULNERABILITY FOUND in $APP_NAME:$VERSION\n• Build stopped at <$PR_URL|PR#$PULL_NUMBER>\n• Logs available <$TEKTON_URL|here>\", \"icon_emoji\": \":shield:\"}" "$SLACK_WEBHOOK_URL" > /dev/null
+            exit 1
+            else
+            echo "EVERYTHING IS OK"
+            fi
         - image: jx3mqubebuild.azurecr.io/spring-financial-group/container-tools:latest
           name: push-sign-verify-containers
           resources: {}

--- a/python314/.trivyignore.yaml
+++ b/python314/.trivyignore.yaml
@@ -1,0 +1,1 @@
+vulnerabilities: []

--- a/python314/.trivyignore.yaml
+++ b/python314/.trivyignore.yaml
@@ -1,1 +1,6 @@
-vulnerabilities: []
+# All from the yq dependency (v4.53.3) running on an older go stdlib version
+vulnerabilities:
+- id: CVE-2026-56852
+  expired_at: 2026-12-31
+- id: CVE-2026-39822
+  expired_at: 2026-12-31

--- a/python314/Dockerfile
+++ b/python314/Dockerfile
@@ -1,6 +1,14 @@
 FROM jx3mqubebuild.azurecr.io/ghcr-io/astral-sh/uv:0.11.19-debian-slim
 
-RUN apt update && apt install -y --no-install-recommends wget make git ca-certificates gcc
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        wget \
+        make \
+        git \
+        ca-certificates \
+        gcc \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG YQ_VERSION=v4.53.3
 ARG YQ_BINARY=yq_linux_amd64

--- a/python314/Dockerfile
+++ b/python314/Dockerfile
@@ -1,4 +1,4 @@
-FROM jx3mqubebuild.azurecr.io/ghcr-io/astral-sh/uv:0.11.19-debian-slim
+FROM jx3mqubebuild.azurecr.io/ghcr-io/astral-sh/uv:0.12.2-debian-slim
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -8,6 +8,12 @@ RUN apt-get update \
         git \
         ca-certificates \
         gcc \
+        libxcb1 \
+        libx11-6 \
+        libxext6 \
+        libxrender1 \
+        libgl1 \
+        libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 ARG YQ_VERSION=v4.53.3
@@ -24,12 +30,3 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt update \
     && apt install gh -y
-
-RUN apt-get update && apt-get install -y \
-    libxcb1 \
-    libx11-6 \
-    libxext6 \
-    libxrender1 \
-    libgl1 \
-    libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Adds "apt-get upgrade" to base python image to upgrade debian deps
- Implements trivy scanning, as Python is the big offender here. To be replaced in future by Docksec.
- Updates uv dependency to latest version 

All leftover vulns are from YQ 
From the wise words of Hubert "they rarely have totally breaking changes" ... will it break anything - "unlikely"