### PR TITLE
chore: install YQ into docksec image

### DIFF
--- a/docksec/.trivyignore.yaml
+++ b/docksec/.trivyignore.yaml
@@ -7,3 +7,8 @@ vulnerabilities:
     expired_at: 2026-09-30
   - id: CVE-2025-47273
     expired_at: 2026-09-30
+  # yq dependency (v4.53.3) is running on an older go stdlib version
+  - id: CVE-2026-56852
+    expired_at: 2026-12-31
+  - id: CVE-2026-39822
+    expired_at: 2026-12-31

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -4,6 +4,7 @@ ARG DOCKSEC_VERSION=2026.7.5
 ARG TRIVY_VERSION=0.73.0
 ARG HADOLINT_VERSION=2.12.0
 ARG DOCKER_VERSION=29.7.1
+ARG YQ_VERSION=4.53.3
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -34,6 +35,10 @@ RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${
          -o /tmp/docker.tgz \
     && tar -xzf /tmp/docker.tgz -C /opt/tools --strip-components=1 docker/docker \
     && rm /tmp/docker.tgz
+
+RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \
+         -o /opt/tools/yq \
+    && chmod +x /opt/tools/yq
 
 FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie
 


### PR DESCRIPTION
### Changes
This will give us more control over the docksec output into the CI/CD steps, as we will be able to parse the results and remove the information that isn't relevant to us.

YQ currently has 2 known dependencies that I have added to the trivyignore.

This is the same way as we currently install within the python step (albeit using curl here rather than wget)