### PR TITLE
refactor: rename chrome-for-testing-golang container

### DIFF
--- a/.lighthouse/jenkins-x/chrome-for-testing-golang/pr.yaml
+++ b/.lighthouse/jenkins-x/chrome-for-testing-golang/pr.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: golang-chromium-release
+  name: chrome-for-testing-golang-pr
 spec:
   pipelineSpec:
     tasks:
@@ -10,7 +10,7 @@ spec:
       taskSpec:
         metadata: {}
         stepTemplate:
-          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/release.yaml@versionStream
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/pullrequest.yaml@versionStream
           name: ""
           resources:
             # override limits for all containers here
@@ -21,16 +21,11 @@ spec:
             name: temp-docker-config
           env:
           - name: IMAGE_NAME
-            value: golang-chromium
+            value: chrome-for-testing-golang
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
-        - name: next-version
-          resources: {}
-          script: |
-            #!/usr/bin/env sh
-            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug
@@ -51,20 +46,12 @@ spec:
             set -e
             source .jx/variables.sh
             cp /temp-docker-config/config.json ~/.docker/config.json
-            
-            # Push the image using crane and get the digest
             IMAGE_REF=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
             crane push /workspace/source/$IMAGE_NAME.tar $IMAGE_REF
             IMAGE_DIGEST=$(crane digest $IMAGE_REF)
             IMAGE_WITH_DIGEST=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME@$IMAGE_DIGEST
-            
-            # Sign the image with cosign and verify the signature
             cosign sign --yes --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
             cosign verify --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
-            
-            # Retag to latest (same digest, no re-sign needed)
-            crane tag $IMAGE_REF latest
-            
             rm -f /workspace/source/$IMAGE_NAME.tar /workspace/source/scanresults.txt
         volumes:
         - name: temp-docker-config

--- a/.lighthouse/jenkins-x/chrome-for-testing-golang/release.yaml
+++ b/.lighthouse/jenkins-x/chrome-for-testing-golang/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: golang-chromium-pr
+  name: chrome-for-testing-golang-release
 spec:
   pipelineSpec:
     tasks:
@@ -10,7 +10,7 @@ spec:
       taskSpec:
         metadata: {}
         stepTemplate:
-          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/pullrequest.yaml@versionStream
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/release.yaml@versionStream
           name: ""
           resources:
             # override limits for all containers here
@@ -21,11 +21,16 @@ spec:
             name: temp-docker-config
           env:
           - name: IMAGE_NAME
-            value: golang-chromium
+            value: chrome-for-testing-golang
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
+        - name: next-version
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version > VERSION
         - name: jx-variables
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.8.0-debug
@@ -46,12 +51,20 @@ spec:
             set -e
             source .jx/variables.sh
             cp /temp-docker-config/config.json ~/.docker/config.json
+            
+            # Push the image using crane and get the digest
             IMAGE_REF=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME:$VERSION
             crane push /workspace/source/$IMAGE_NAME.tar $IMAGE_REF
             IMAGE_DIGEST=$(crane digest $IMAGE_REF)
             IMAGE_WITH_DIGEST=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$IMAGE_NAME@$IMAGE_DIGEST
+            
+            # Sign the image with cosign and verify the signature
             cosign sign --yes --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
             cosign verify --key k8s://jx-staging/cosign $IMAGE_WITH_DIGEST
+            
+            # Retag to latest (same digest, no re-sign needed)
+            crane tag $IMAGE_REF latest
+            
             rm -f /workspace/source/$IMAGE_NAME.tar /workspace/source/scanresults.txt
         volumes:
         - name: temp-docker-config

--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -82,10 +82,10 @@ spec:
     optional: false
     run_if_changed: (README.md|^.*chrome-for-testing\/.*$)
     source: "/chrome-for-testing/pr.yaml"
-  - name: golang-chromium-pr
+  - name: chrome-for-testing-golang-pr
     optional: false
-    run_if_changed: (README.md|^.*golang-chromium\/.*$)
-    source: "/golang-chromium/pr.yaml"
+    run_if_changed: (README.md|^.*chrome-for-testing-golang\/.*$)
+    source: "/chrome-for-testing-golang/pr.yaml"
   - name: black-arch-pr
     optional: false
     run_if_changed: (README.md|^.*black-arch\/.*$)
@@ -211,8 +211,8 @@ spec:
     branches:
     - ^main$
     - ^master$
-  - name: golang-chromium-release
-    source: "/golang-chromium/release.yaml"
+  - name: chrome-for-testing-golang-release
+    source: "/chrome-for-testing-golang/release.yaml"
     branches:
     - ^main$
     - ^master$

--- a/chrome-for-testing-golang/Dockerfile
+++ b/chrome-for-testing-golang/Dockerfile
@@ -1,0 +1,6 @@
+FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:1.26.5 AS golang
+
+FROM jx3mqubebuild.azurecr.io/spring-financial-group/chrome-for-testing:latest
+COPY --from=golang /usr/local/go /usr/local/go
+
+ENV PATH="/usr/local/go/bin:${PATH}"

--- a/chrome-for-testing-golang/Dockerfile
+++ b/chrome-for-testing-golang/Dockerfile
@@ -1,6 +1,11 @@
 FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:1.26.5 AS golang
 
 FROM jx3mqubebuild.azurecr.io/spring-financial-group/chrome-for-testing:latest
+
 COPY --from=golang /usr/local/go /usr/local/go
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    make \
+ && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/usr/local/go/bin:${PATH}"

--- a/golang-chromium/Dockerfile
+++ b/golang-chromium/Dockerfile
@@ -1,5 +1,0 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/golang:1.26
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends chromium \
-    && apt-get clean


### PR DESCRIPTION
### Changes
- rename golang-chromium to chrome-for-testing-golang
- base off of chrome-for-testing container

### Context

Ensure that the same container is used in deployment, is also used in testing