### PR TITLE
fix: set env vars for go chrome for testing container

### DIFF
--- a/chrome-for-testing-golang/Dockerfile
+++ b/chrome-for-testing-golang/Dockerfile
@@ -8,4 +8,10 @@ RUN apt-get update \
     make \
  && rm -rf /var/lib/apt/lists/*
 
-ENV PATH="/usr/local/go/bin:${PATH}"
+# Match the official golang image defaults.
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/go
+ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+
+RUN mkdir -p "$GOPATH"/{src,pkg,bin}
+WORKDIR $GOPATH


### PR DESCRIPTION
### Changes
- fix env vars for chrome-for-testing-golang

### Context

Need go env vars set, like in the base golang image, so that go tools install and are available in the path