### PR TITLE
chore: use dhi image for docksec

### DIFF
--- a/.lighthouse/jenkins-x/docksec/pr.yaml
+++ b/.lighthouse/jenkins-x/docksec/pr.yaml
@@ -28,7 +28,7 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
-        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+        - image: gcr.io/kaniko-project/executor:v1.24.0-debug
           name: build-containers
           resources: {}
           script: |

--- a/.lighthouse/jenkins-x/docksec/release.yaml
+++ b/.lighthouse/jenkins-x/docksec/release.yaml
@@ -33,7 +33,7 @@ spec:
             jx-release-version > VERSION
         - name: jx-variables
           resources: {}
-        - image: gcr.io/kaniko-project/executor:v1.8.0-debug
+        - image: gcr.io/kaniko-project/executor:v1.24.0-debug
           name: build-containers
           resources: {}
           script: |

--- a/docksec/.trivyignore.yaml
+++ b/docksec/.trivyignore.yaml
@@ -1,6 +1,8 @@
 vulnerabilities:
-  # CVE-2026-50163 (oras-go v2.6.1) - trivy has a dependencybot PR merging as I'm typing this
+  # trivy vulnerabilities - oras & go-git
   - id: CVE-2026-50163
+    expired_at: 2026-08-31
+  - id: CVE-2026-71556
     expired_at: 2026-08-31
   # due to Python (transitive deps pulled in by docksec[ai]): https://github.com/OWASP/DockSec/pull/93
   - id: GHSA-6v7p-g79w-8964

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -25,23 +25,24 @@ RUN mkdir -p /opt/tools \
          "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
          -o /tmp/trivy.tar.gz \
     && tar -xzf /tmp/trivy.tar.gz -C /opt/tools trivy \
-    && rm /tmp/trivy.tar.gz
-
-RUN curl -fsSL \
+    && rm /tmp/trivy.tar.gz \
+    && curl -fsSL \
          "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
          -o /opt/tools/hadolint \
-    && chmod +x /opt/tools/hadolint
-
-RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
+    && chmod +x /opt/tools/hadolint \
+    && curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
          -o /tmp/docker.tgz \
     && tar -xzf /tmp/docker.tgz -C /opt/tools --strip-components=1 docker/docker \
-    && rm /tmp/docker.tgz
-
-RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \
+    && rm /tmp/docker.tgz \
+    && curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \
          -o /opt/tools/yq \
     && chmod +x /opt/tools/yq
 
 FROM dhi.io/python:3.14-debian-dev
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/docksec-venv /opt/docksec-venv
 COPY --from=builder /opt/tools/ /usr/local/bin/

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -1,4 +1,4 @@
-FROM dhi.io/python:3.14-debian AS builder
+FROM dhi.io/python:3.14-debian-dev AS builder
 
 ARG DOCKSEC_VERSION=2026.7.5
 ARG TRIVY_VERSION=0.73.0
@@ -10,6 +10,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        gzip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m venv /opt/docksec-venv
@@ -40,11 +41,7 @@ RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}
          -o /opt/tools/yq \
     && chmod +x /opt/tools/yq
 
-FROM dhi.io/python:3.14-debian
-
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && rm -rf /var/lib/apt/lists/*
+FROM dhi.io/python:3.14-debian-dev
 
 COPY --from=builder /opt/docksec-venv /opt/docksec-venv
 COPY --from=builder /opt/tools/ /usr/local/bin/

--- a/docksec/Dockerfile
+++ b/docksec/Dockerfile
@@ -1,4 +1,4 @@
-FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie AS builder
+FROM dhi.io/python:3.14-debian AS builder
 
 ARG DOCKSEC_VERSION=2026.7.5
 ARG TRIVY_VERSION=0.73.0
@@ -40,7 +40,7 @@ RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}
          -o /opt/tools/yq \
     && chmod +x /opt/tools/yq
 
-FROM jx3mqubebuild.azurecr.io/docker-io/library/python:3.14-slim-trixie
+FROM dhi.io/python:3.14-debian
 
 RUN apt-get update \
     && apt-get upgrade -y \


### PR DESCRIPTION
### Changes
* use dhi.io for docksec
* install curl in runtime img (there are too many dependencies to copy over from build container)

### Context
* a lot of vulnerabilities in base python image
