### PR TITLE
feat: add g++ and other libs for ml images

### DIFF
--- a/python314/.trivyignore.yaml
+++ b/python314/.trivyignore.yaml
@@ -4,3 +4,7 @@ vulnerabilities:
   expired_at: 2026-12-31
 - id: CVE-2026-39822
   expired_at: 2026-12-31
+- id: CVE-2026-46600
+  expired_at: 2026-12-31
+- id: CVE-2026-42505
+  expired_at: 2026-12-31

--- a/python314/Dockerfile
+++ b/python314/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update \
         git \
         ca-certificates \
         gcc \
+        g++ \
+        libc-dev \
+        libffi-dev \
         libxcb1 \
         libx11-6 \
         libxext6 \


### PR DESCRIPTION
### Changes
* adding g++ libc-dev and libffi-dev
* Trivyignores for bundled Go dependencies with yq. Fix has not been made upstream yet

### Context
Some dev packages and g++ for ML images to run neural models