### PR TITLE
chore: install git in all-sdks-dbian

### DIFF
--- a/all-sdks-debian/Dockerfile
+++ b/all-sdks-debian/Dockerfile
@@ -38,6 +38,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         unzip \
         xz-utils \
         zstd \
+        git \
         gcc \
         g++ \
         make \


### PR DESCRIPTION
### Changes
Making changes so that the go-openapi-generator uses the 'all-sdks-debian' image. As it's currently using the UV image then installing Go and Java on top of that.

I don't think we want to know how many vulns are in this dockerfile 😂 

The difference is the base UV img has git, but all-sdks-debian does not, which means my openapi generator PR is failing saying git is not in PATH